### PR TITLE
chore: Remove unnecessary dependencies and `Config.swift`

### DIFF
--- a/.github/workflows/conventional-pr.yml
+++ b/.github/workflows/conventional-pr.yml
@@ -16,3 +16,5 @@ jobs:
       - uses: CondeNast/conventional-pull-request-action@v0.2.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          commitTitleMatch: "false"

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,30 +1,12 @@
 {
   "pins" : [
     {
-      "identity" : "asynchrone",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/reddavis/Asynchrone",
-      "state" : {
-        "revision" : "1ddfcd3bc93277f68dffb793fc60001902f2517b",
-        "version" : "0.22.0"
-      }
-    },
-    {
-      "identity" : "combinex",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/cx-org/CombineX",
-      "state" : {
-        "revision" : "98096c6b2a51481cb6e4bae8da0a808d8cab09a1",
-        "version" : "0.4.0"
-      }
-    },
-    {
       "identity" : "rainbow",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/onevcat/Rainbow",
       "state" : {
-        "revision" : "e0dada9cd44e3fa7ec3b867e49a8ddbf543e3df3",
-        "version" : "4.0.1"
+        "revision" : "0c627a4f8a39ef37eadec1ceec02e4a7f55561ac",
+        "version" : "4.1.0"
       }
     },
     {
@@ -34,15 +16,6 @@
       "state" : {
         "revision" : "41982a3656a71c768319979febd796c6fd111d5c",
         "version" : "1.5.0"
-      }
-    },
-    {
-      "identity" : "swift-atomics",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-atomics.git",
-      "state" : {
-        "revision" : "3e95ba32cd1b4c877f6163e8eea54afc4e63bf9f",
-        "version" : "0.0.3"
       }
     }
   ],

--- a/Package.swift
+++ b/Package.swift
@@ -19,21 +19,21 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/onevcat/Rainbow", .upToNextMajor(from: "4.1.0")),
-        .package(url: "https://github.com/cx-org/CombineX", .upToNextMajor(from: "0.4.0")),
-        .package(url: "https://github.com/reddavis/Asynchrone", .upToNextMajor(from: "0.22.0")),
-        .package(url: "https://github.com/apple/swift-argument-parser", .upToNextMajor(from: "1.5.0")),
+        .package(
+            url: "https://github.com/apple/swift-argument-parser", .upToNextMajor(from: "1.5.0")
+        ),
     ],
     targets: [
         .executableTarget(
             name: "examples-cli",
-            dependencies: ["Noora", .product(name: "ArgumentParser", package: "swift-argument-parser")]
+            dependencies: [
+                "Noora", .product(name: "ArgumentParser", package: "swift-argument-parser"),
+            ]
         ),
         .target(
             name: "Noora",
             dependencies: [
                 "Rainbow",
-                "CombineX",
-                "Asynchrone",
             ],
             swiftSettings: [
                 .define("MOCKING", .when(configuration: .debug)),

--- a/Tuist/Config.swift
+++ b/Tuist/Config.swift
@@ -1,3 +1,0 @@
-import ProjectDescription
-
-let config = Config(cloud: .cloud(projectId: "tuist/noora"))


### PR DESCRIPTION
- I'm removing `CombineX` and `Asynchrone`, which are not really needed for this project. They are heavy dependencies and the functionality that we use from them can also be replicated with `Foundation`.
- Since we use SPM as a build tool, we don't need a `Config.swift` file, so I'm removing it.