### PR TITLE
feat: Support runtime options in the SingleChoicePrompt

### DIFF
--- a/Sources/Noora/Components/SingleChoicePrompt.swift
+++ b/Sources/Noora/Components/SingleChoicePrompt.swift
@@ -1,13 +1,12 @@
 import Foundation
 import Rainbow
 
-struct SingleChoicePrompt<T: CaseIterable & CustomStringConvertible & Equatable> {
+struct SingleChoicePrompt {
     // MARK: - Attributes
 
     let title: TerminalText?
     let question: TerminalText
     let description: TerminalText?
-    let options: T.Type
     let theme: Theme
     let terminal: Terminaling
     let collapseOnSelection: Bool
@@ -15,29 +14,35 @@ struct SingleChoicePrompt<T: CaseIterable & CustomStringConvertible & Equatable>
     let standardPipelines: StandardPipelines
     let keyStrokeListener: KeyStrokeListening
 
-    func run() -> T {
-        if !terminal.isInteractive {
-            fatalError("'\(question)' can't be prompted in a non-interactive session.")
-        }
+    func run<T: CustomStringConvertible & Equatable>(options: [T]) -> T {
+        run(options: options.map { ($0, $0.description) })
+    }
 
-        let allOptions = Array(T.allCases)
-        var selectedOption: T! = allOptions.first
+    func run<T: CaseIterable & CustomStringConvertible & Equatable>() -> T {
+        run(options: Array(T.allCases).map { ($0, $0.description) })
+    }
+
+    // MARK: - Private
+
+    private func run<T: Equatable>(options: [(T, String)]) -> T {
+        var options = options
+        var selectedOption: (T, String)! = options.first
 
         terminal.inRawMode {
-            renderOptions(selectedOption: selectedOption)
+            renderOptions(selectedOption: selectedOption, options: options)
             keyStrokeListener.listen(terminal: terminal) { keyStroke in
                 switch keyStroke {
                 case .returnKey:
                     return .abort
                 case .kKey, .upArrowKey:
-                    let currentIndex = allOptions.firstIndex(where: { $0 == selectedOption })!
-                    selectedOption = allOptions[(currentIndex - 1 + allOptions.count) % allOptions.count]
-                    renderOptions(selectedOption: selectedOption)
+                    let currentIndex = options.firstIndex(where: { $0 == selectedOption })!
+                    selectedOption = options[(currentIndex - 1 + options.count) % options.count]
+                    renderOptions(selectedOption: selectedOption, options: options)
                     return .continue
                 case .jKey, .downArrowKey:
-                    let currentIndex = allOptions.firstIndex(where: { $0 == selectedOption })!
-                    selectedOption = allOptions[(currentIndex + 1 + allOptions.count) % allOptions.count]
-                    renderOptions(selectedOption: selectedOption)
+                    let currentIndex = options.firstIndex(where: { $0 == selectedOption })!
+                    selectedOption = options[(currentIndex + 1 + options.count) % options.count]
+                    renderOptions(selectedOption: selectedOption, options: options)
                     return .continue
                 default:
                     return .continue
@@ -49,12 +54,10 @@ struct SingleChoicePrompt<T: CaseIterable & CustomStringConvertible & Equatable>
             renderResult(selectedOption: selectedOption)
         }
 
-        return selectedOption
+        return selectedOption.0
     }
 
-    // MARK: - Private
-
-    private func renderResult(selectedOption: T) {
+    private func renderResult(selectedOption: (some Equatable, String)) {
         var content = if let title {
             "\(title.formatted(theme: theme, terminal: terminal)):".hexIfColoredTerminal(theme.primary, terminal)
                 .boldIfColoredTerminal(terminal)
@@ -62,21 +65,19 @@ struct SingleChoicePrompt<T: CaseIterable & CustomStringConvertible & Equatable>
             "\(question.formatted(theme: theme, terminal: terminal)):".hexIfColoredTerminal(theme.primary, terminal)
                 .boldIfColoredTerminal(terminal)
         }
-        content += " \(selectedOption.description)"
+        content += " \(selectedOption.1)"
         renderer.render(
             ProgressStep.completionMessage(content, theme: theme, terminal: terminal),
             standardPipeline: standardPipelines.output
         )
     }
 
-    private func renderOptions(selectedOption: T) {
-        let options = Array(options.allCases)
-
+    private func renderOptions<T: Equatable>(selectedOption: (T, String), options: [(T, String)]) {
         let questions = options.map { option in
             if option == selectedOption {
-                return "   \("❯".hex(theme.primary)) \(option.description)"
+                return "   \("❯".hex(theme.primary)) \(option.1)"
             } else {
-                return "     \(option.description)"
+                return "     \(option.1)"
             }
         }.joined(separator: "\n")
         var content = ""

--- a/Sources/Noora/Components/SingleChoicePrompt.swift
+++ b/Sources/Noora/Components/SingleChoicePrompt.swift
@@ -25,6 +25,9 @@ struct SingleChoicePrompt {
     // MARK: - Private
 
     private func run<T: Equatable>(options: [(T, String)]) -> T {
+        if !terminal.isInteractive {
+            fatalError("'\(question)' can't be prompted in a non-interactive session.")
+        }
         var options = options
         var selectedOption: (T, String)! = options.first
 

--- a/Sources/Noora/Noora.swift
+++ b/Sources/Noora/Noora.swift
@@ -66,7 +66,7 @@ public protocol Noorable {
     /// It shows multiple options to the user to select one.
     /// - Parameters:
     ///   - title: A title that captures what's being asked.
-    ///   - question: The quetion to ask to the user.
+    ///   - question: The question to ask to the user.
     ///   - options: The options to show to the user.
     ///   - description: Use it to add some explanation to what the question is for.
     ///   - collapseOnSelection: Whether the prompt should collapse after the user selects an option.

--- a/Sources/Noora/Noora.swift
+++ b/Sources/Noora/Noora.swift
@@ -58,6 +58,27 @@ public struct ErrorAlert: ExpressibleByStringLiteral {
 }
 
 public protocol Noorable {
+    func singleChoicePrompt<T: Equatable & CustomStringConvertible>(
+        question: TerminalText,
+        options: [T]
+    ) -> T
+
+    /// It shows multiple options to the user to select one.
+    /// - Parameters:
+    ///   - title: A title that captures what's being asked.
+    ///   - question: The quetion to ask to the user.
+    ///   - options: The options to show to the user.
+    ///   - description: Use it to add some explanation to what the question is for.
+    ///   - collapseOnSelection: Whether the prompt should collapse after the user selects an option.
+    /// - Returns: The option selected by the user.
+    func singleChoicePrompt<T: Equatable & CustomStringConvertible>(
+        title: TerminalText?,
+        question: TerminalText,
+        options: [T],
+        description: TerminalText?,
+        collapseOnSelection: Bool
+    ) -> T
+
     func singleChoicePrompt<T: CaseIterable & CustomStringConvertible & Equatable>(
         question: TerminalText
     ) -> T
@@ -148,6 +169,31 @@ public struct Noora: Noorable {
         self.terminal = terminal
     }
 
+    public func singleChoicePrompt<T>(question: TerminalText, options: [T]) -> T where T: CustomStringConvertible, T: Equatable {
+        singleChoicePrompt(title: nil, question: question, options: options, description: nil, collapseOnSelection: true)
+    }
+
+    public func singleChoicePrompt<T>(
+        title: TerminalText?,
+        question: TerminalText,
+        options: [T],
+        description: TerminalText?,
+        collapseOnSelection: Bool
+    ) -> T where T: CustomStringConvertible, T: Equatable {
+        let component = SingleChoicePrompt(
+            title: title,
+            question: question,
+            description: description,
+            theme: theme,
+            terminal: terminal,
+            collapseOnSelection: collapseOnSelection,
+            renderer: Renderer(),
+            standardPipelines: StandardPipelines(),
+            keyStrokeListener: KeyStrokeListener()
+        )
+        return component.run(options: options)
+    }
+
     public func singleChoicePrompt<T>(question: TerminalText) -> T where T: CaseIterable, T: CustomStringConvertible,
         T: Equatable
     {
@@ -160,11 +206,10 @@ public struct Noora: Noorable {
         description: TerminalText? = nil,
         collapseOnSelection: Bool = true
     ) -> T {
-        let component = SingleChoicePrompt<T>(
+        let component = SingleChoicePrompt(
             title: title,
             question: question,
             description: description,
-            options: T.self,
             theme: theme,
             terminal: terminal,
             collapseOnSelection: collapseOnSelection,

--- a/Sources/Noora/Noora.swift
+++ b/Sources/Noora/Noora.swift
@@ -57,12 +57,71 @@ public struct ErrorAlert: ExpressibleByStringLiteral {
     }
 }
 
-public protocol Noorable {
-    func singleChoicePrompt<T: Equatable & CustomStringConvertible>(
+extension Noorable {
+    public func singleChoicePrompt<T: Equatable & CustomStringConvertible>(
+        title: TerminalText? = nil,
         question: TerminalText,
-        options: [T]
-    ) -> T
+        options: [T],
+        description: TerminalText? = nil,
+        collapseOnSelection: Bool = true
+    ) -> T {
+        singleChoicePrompt(
+            title: title,
+            question: question,
+            options: options,
+            description: description,
+            collapseOnSelection: collapseOnSelection
+        )
+    }
 
+    public func singleChoicePrompt<T: CaseIterable & CustomStringConvertible & Equatable>(
+        title: TerminalText? = nil,
+        question: TerminalText,
+        description: TerminalText? = nil,
+        collapseOnSelection: Bool = true
+    ) -> T {
+        singleChoicePrompt(
+            title: title,
+            question: question,
+            description: description,
+            collapseOnSelection: collapseOnSelection
+        )
+    }
+
+    public func yesOrNoChoicePrompt(
+        title: TerminalText? = nil,
+        question: TerminalText,
+        defaultAnswer: Bool = true,
+        description: TerminalText? = nil,
+        collapseOnSelection: Bool = true
+    ) -> Bool {
+        yesOrNoChoicePrompt(
+            title: title,
+            question: question,
+            defaultAnswer: defaultAnswer,
+            description: description,
+            collapseOnSelection: collapseOnSelection
+        )
+    }
+
+    public func progressStep(
+        message: String,
+        successMessage: String? = nil,
+        errorMessage: String? = nil,
+        showSpinner: Bool = true,
+        action: @escaping ((String) -> Void) async throws -> Void
+    ) async throws {
+        try await progressStep(
+            message: message,
+            successMessage: successMessage,
+            errorMessage: errorMessage,
+            showSpinner: showSpinner,
+            action: action
+        )
+    }
+}
+
+public protocol Noorable {
     /// It shows multiple options to the user to select one.
     /// - Parameters:
     ///   - title: A title that captures what's being asked.
@@ -79,10 +138,6 @@ public protocol Noorable {
         collapseOnSelection: Bool
     ) -> T
 
-    func singleChoicePrompt<T: CaseIterable & CustomStringConvertible & Equatable>(
-        question: TerminalText
-    ) -> T
-
     /// It shows multiple options to the user to select one.
     /// - Parameters:
     ///   - title: A title that captures what's being asked.
@@ -96,11 +151,6 @@ public protocol Noorable {
         description: TerminalText?,
         collapseOnSelection: Bool
     ) -> T
-
-    func yesOrNoChoicePrompt(
-        title: TerminalText?,
-        question: TerminalText
-    ) -> Bool
 
     /// It shows a component to answer yes or no to a question.
     /// - Parameters:
@@ -136,16 +186,6 @@ public protocol Noorable {
     /// Shows a progress step.
     /// - Parameters:
     ///   - message: The message that represents "what's being done"
-    ///   - action: The asynchronous task to run. The caller can use the argument that the function takes to update the step
-    /// message.
-    func progressStep(
-        message: String,
-        action: @escaping ((String) -> Void) async throws -> Void
-    ) async throws
-
-    /// Shows a progress step.
-    /// - Parameters:
-    ///   - message: The message that represents "what's being done"
     ///   - successMessage: The message that the step gets updated to when the action completes.
     ///   - errorMessage: The message that the step gets updated to when the action errors.
     ///   - showSpinner: True to show a spinner.
@@ -169,10 +209,6 @@ public struct Noora: Noorable {
         self.terminal = terminal
     }
 
-    public func singleChoicePrompt<T>(question: TerminalText, options: [T]) -> T where T: CustomStringConvertible, T: Equatable {
-        singleChoicePrompt(title: nil, question: question, options: options, description: nil, collapseOnSelection: true)
-    }
-
     public func singleChoicePrompt<T>(
         title: TerminalText?,
         question: TerminalText,
@@ -194,12 +230,6 @@ public struct Noora: Noorable {
         return component.run(options: options)
     }
 
-    public func singleChoicePrompt<T>(question: TerminalText) -> T where T: CaseIterable, T: CustomStringConvertible,
-        T: Equatable
-    {
-        singleChoicePrompt(title: nil, question: question, description: nil, collapseOnSelection: true)
-    }
-
     public func singleChoicePrompt<T: CaseIterable & CustomStringConvertible & Equatable>(
         title: TerminalText? = nil,
         question: TerminalText,
@@ -218,10 +248,6 @@ public struct Noora: Noorable {
             keyStrokeListener: KeyStrokeListener()
         )
         return component.run()
-    }
-
-    public func yesOrNoChoicePrompt(title: TerminalText?, question: TerminalText) -> Bool {
-        yesOrNoChoicePrompt(title: title, question: question, defaultAnswer: true, description: nil, collapseOnSelection: true)
     }
 
     public func yesOrNoChoicePrompt(
@@ -270,10 +296,6 @@ public struct Noora: Noorable {
             terminal: terminal,
             theme: theme
         ).run()
-    }
-
-    public func progressStep(message: String, action: @escaping ((String) -> Void) async throws -> Void) async throws {
-        try await progressStep(message: message, successMessage: nil, errorMessage: nil, showSpinner: true, action: action)
     }
 
     public func progressStep(

--- a/Sources/Noora/Noora.swift
+++ b/Sources/Noora/Noora.swift
@@ -57,70 +57,6 @@ public struct ErrorAlert: ExpressibleByStringLiteral {
     }
 }
 
-extension Noorable {
-    public func singleChoicePrompt<T: Equatable & CustomStringConvertible>(
-        title: TerminalText? = nil,
-        question: TerminalText,
-        options: [T],
-        description: TerminalText? = nil,
-        collapseOnSelection: Bool = true
-    ) -> T {
-        singleChoicePrompt(
-            title: title,
-            question: question,
-            options: options,
-            description: description,
-            collapseOnSelection: collapseOnSelection
-        )
-    }
-
-    public func singleChoicePrompt<T: CaseIterable & CustomStringConvertible & Equatable>(
-        title: TerminalText? = nil,
-        question: TerminalText,
-        description: TerminalText? = nil,
-        collapseOnSelection: Bool = true
-    ) -> T {
-        singleChoicePrompt(
-            title: title,
-            question: question,
-            description: description,
-            collapseOnSelection: collapseOnSelection
-        )
-    }
-
-    public func yesOrNoChoicePrompt(
-        title: TerminalText? = nil,
-        question: TerminalText,
-        defaultAnswer: Bool = true,
-        description: TerminalText? = nil,
-        collapseOnSelection: Bool = true
-    ) -> Bool {
-        yesOrNoChoicePrompt(
-            title: title,
-            question: question,
-            defaultAnswer: defaultAnswer,
-            description: description,
-            collapseOnSelection: collapseOnSelection
-        )
-    }
-
-    public func progressStep(
-        message: String,
-        successMessage: String? = nil,
-        errorMessage: String? = nil,
-        showSpinner: Bool = true,
-        action: @escaping ((String) -> Void) async throws -> Void
-    ) async throws {
-        try await progressStep(
-            message: message,
-            successMessage: successMessage,
-            errorMessage: errorMessage,
-            showSpinner: showSpinner,
-            action: action
-        )
-    }
-}
-
 public protocol Noorable {
     /// It shows multiple options to the user to select one.
     /// - Parameters:
@@ -317,5 +253,69 @@ public struct Noora: Noorable {
             standardPipelines: StandardPipelines()
         )
         try await progressStep.run()
+    }
+}
+
+extension Noorable {
+    public func singleChoicePrompt<T: Equatable & CustomStringConvertible>(
+        title: TerminalText? = nil,
+        question: TerminalText,
+        options: [T],
+        description: TerminalText? = nil,
+        collapseOnSelection: Bool = true
+    ) -> T {
+        singleChoicePrompt(
+            title: title,
+            question: question,
+            options: options,
+            description: description,
+            collapseOnSelection: collapseOnSelection
+        )
+    }
+
+    public func singleChoicePrompt<T: CaseIterable & CustomStringConvertible & Equatable>(
+        title: TerminalText? = nil,
+        question: TerminalText,
+        description: TerminalText? = nil,
+        collapseOnSelection: Bool = true
+    ) -> T {
+        singleChoicePrompt(
+            title: title,
+            question: question,
+            description: description,
+            collapseOnSelection: collapseOnSelection
+        )
+    }
+
+    public func yesOrNoChoicePrompt(
+        title: TerminalText? = nil,
+        question: TerminalText,
+        defaultAnswer: Bool = true,
+        description: TerminalText? = nil,
+        collapseOnSelection: Bool = true
+    ) -> Bool {
+        yesOrNoChoicePrompt(
+            title: title,
+            question: question,
+            defaultAnswer: defaultAnswer,
+            description: description,
+            collapseOnSelection: collapseOnSelection
+        )
+    }
+
+    public func progressStep(
+        message: String,
+        successMessage: String? = nil,
+        errorMessage: String? = nil,
+        showSpinner: Bool = true,
+        action: @escaping ((String) -> Void) async throws -> Void
+    ) async throws {
+        try await progressStep(
+            message: message,
+            successMessage: successMessage,
+            errorMessage: errorMessage,
+            showSpinner: showSpinner,
+            action: action
+        )
     }
 }

--- a/Tests/NooraTests/Components/SingleChoicePromptTests.swift
+++ b/Tests/NooraTests/Components/SingleChoicePromptTests.swift
@@ -23,7 +23,6 @@ struct SingleChoicePromptTests {
             title: "Integration",
             question: "How would you like to integrate Tuist?",
             description: "Decide how the integration should be with your project",
-            options: Option.self,
             theme: Theme.test(),
             terminal: terminal,
             collapseOnSelection: true,
@@ -34,7 +33,7 @@ struct SingleChoicePromptTests {
         keyStrokeListener.keyPressStub = [.downArrowKey, .upArrowKey]
 
         // When
-        _ = subject.run()
+        let _: Option = subject.run()
 
         // Then
         var renders = Array(renderer.renders.reversed())

--- a/docs/content/components/prompts/single-choice.md
+++ b/docs/content/components/prompts/single-choice.md
@@ -18,7 +18,7 @@ This component is a simple component that prompts the user to select a single op
 
 ## API
 
-### Example
+### Example with a case iterable enum
 
 ```swift
 enum ProjectOption: String, CaseIterable, CustomStringConvertible {
@@ -41,6 +41,21 @@ enum ProjectOption: String, CaseIterable, CustomStringConvertible {
 let selectedOption: ProjectOption = Noora().singleChoicePrompt(
     title: "Project",
     question: "Would you like to create a new Tuist project or use an existing Xcode project?",
+    description: "Tuist extend the capabilities of your projects.",
+    theme: NooraTheme.tuist()
+)
+```
+
+### Example with an equatable and custom-string-convertible type
+
+```swift
+let selectedOption: String = Noora().singleChoicePrompt(
+    title: "Project",
+    question: "Would you like to create a new Tuist project or use an existing Xcode project?",
+    options: [
+        "Create a new project",
+        "Use existing Xcode project"
+    ]
     description: "Tuist extend the capabilities of your projects.",
     theme: NooraTheme.tuist()
 )

--- a/docs/content/components/prompts/single-choice.md
+++ b/docs/content/components/prompts/single-choice.md
@@ -46,7 +46,7 @@ let selectedOption: ProjectOption = Noora().singleChoicePrompt(
 )
 ```
 
-### Example with an equatable and custom-string-convertible type
+### Example with an `Equatable` and `CustomStringConvertible` type
 
 ```swift
 let selectedOption: String = Noora().singleChoicePrompt(

--- a/docs/content/components/prompts/single-choice.md
+++ b/docs/content/components/prompts/single-choice.md
@@ -49,7 +49,7 @@ let selectedOption: ProjectOption = Noora().singleChoicePrompt(
 ### Example with an `Equatable` and `CustomStringConvertible` type
 
 ```swift
-let selectedOption: String = Noora().singleChoicePrompt(
+let selectedOption = Noora().singleChoicePrompt(
     title: "Project",
     question: "Would you like to create a new Tuist project or use an existing Xcode project?",
     options: [


### PR DESCRIPTION
I noticed "SingleChoicePrompt" is designed to only support list of options resolved at compile time. However, this is restrictive in cases where the options are resolved at runtime. This PR extends the API to bring that flexibility.