### PR TITLE
fix: make the closure passed to the task closure @escaping

### DIFF
--- a/Sources/Noora/Components/CollapsibleStep.swift
+++ b/Sources/Noora/Components/CollapsibleStep.swift
@@ -64,13 +64,16 @@ struct CollapsibleStep {
 
     func runInteractive() async throws {
         renderInteractiveLines(lines: [])
-        var lines: [TerminalText] = []
+        var lines: [String] = []
         do {
-            try await task { line in
-                lines.append(line)
-                if lines.count > visibleLines {
-                    lines.removeFirst()
+            try await task { logs in
+                for logLine in logs.formatted(theme: theme, terminal: terminal).split(separator: "\n") {
+                    lines.append(String(logLine))
+                    if lines.count > visibleLines {
+                        lines.removeFirst()
+                    }
                 }
+
                 renderInteractiveLines(lines: lines)
             }
         } catch {
@@ -114,11 +117,11 @@ struct CollapsibleStep {
         }
     }
 
-    private func renderInteractiveLines(lines: [TerminalText]) {
+    private func renderInteractiveLines(lines: [String]) {
         var content = "◉ \(title.formatted(theme: theme, terminal: terminal))".hexIfColoredTerminal(theme.primary, terminal)
             .boldIfColoredTerminal(terminal)
-        for (index, line) in lines.enumerated() {
-            content.append("\n  \(line.formatted(theme: theme, terminal: terminal))")
+        for line in lines {
+            content.append("\n  \(line)")
         }
         renderer.render(content, standardPipeline: standardPipelines.output)
     }

--- a/Sources/Noora/Components/ProgressStep.swift
+++ b/Sources/Noora/Components/ProgressStep.swift
@@ -114,7 +114,7 @@ struct ProgressStep {
         } catch {
             renderer.render(
                 ProgressStep.errorMessage(
-                    (errorMessage ?? message).hexIfColoredTerminal(theme.primary, terminal).boldIfColoredTerminal(terminal),
+                    (errorMessage ?? message).hexIfColoredTerminal(theme.danger, terminal).boldIfColoredTerminal(terminal),
                     timeString: timeString(start: start),
                     theme: theme,
                     terminal: terminal

--- a/Sources/Noora/Components/ProgressStep.swift
+++ b/Sources/Noora/Components/ProgressStep.swift
@@ -104,7 +104,7 @@ struct ProgressStep {
             renderer.render(
                 ProgressStep
                     .completionMessage(
-                        successMessage ?? message,
+                        (successMessage ?? message).hexIfColoredTerminal(theme.primary, terminal).boldIfColoredTerminal(terminal),
                         timeString: timeString(start: start),
                         theme: theme,
                         terminal: terminal
@@ -114,7 +114,7 @@ struct ProgressStep {
         } catch {
             renderer.render(
                 ProgressStep.errorMessage(
-                    errorMessage ?? message,
+                    (errorMessage ?? message).hexIfColoredTerminal(theme.primary, terminal).boldIfColoredTerminal(terminal),
                     timeString: timeString(start: start),
                     theme: theme,
                     terminal: terminal
@@ -126,11 +126,11 @@ struct ProgressStep {
     }
 
     static func completionMessage(_ message: String, timeString: String? = nil, theme: Theme, terminal: Terminaling) -> String {
-        "\("✔︎".hexIfColoredTerminal(theme.success, terminal)) \(message.hexIfColoredTerminal(theme.primary, terminal))\(" \(timeString ?? "")")"
+        "\("✔︎".hexIfColoredTerminal(theme.success, terminal)) \(message)\(" \(timeString ?? "")")"
     }
 
     static func errorMessage(_ message: String, timeString: String? = nil, theme: Theme, terminal: Terminaling) -> String {
-        "\("⨯".hexIfColoredTerminal(theme.danger, terminal)) \(message.hexIfColoredTerminal(theme.primary, terminal)) \(timeString ?? "")"
+        "\("⨯".hexIfColoredTerminal(theme.danger, terminal)) \(message) \(timeString ?? "")"
     }
 
     private func render(message: String, icon: String) {

--- a/Sources/Noora/Components/ProgressStep.swift
+++ b/Sources/Noora/Components/ProgressStep.swift
@@ -8,7 +8,7 @@ struct ProgressStep {
     let successMessage: String?
     let errorMessage: String?
     let showSpinner: Bool
-    let action: (@escaping (String) -> Void) async throws -> Void
+    let task: (@escaping (String) -> Void) async throws -> Void
     let theme: Theme
     let terminal: Terminaling
     let renderer: Rendering
@@ -20,7 +20,7 @@ struct ProgressStep {
         successMessage: String?,
         errorMessage: String?,
         showSpinner: Bool,
-        action: @escaping (@escaping (String) -> Void) async throws -> Void,
+        task: @escaping (@escaping (String) -> Void) async throws -> Void,
         theme: Theme,
         terminal: Terminaling,
         renderer: Rendering,
@@ -31,7 +31,7 @@ struct ProgressStep {
         self.successMessage = successMessage
         self.errorMessage = errorMessage
         self.showSpinner = showSpinner
-        self.action = action
+        self.task = task
         self.theme = theme
         self.terminal = terminal
         self.renderer = renderer
@@ -53,7 +53,7 @@ struct ProgressStep {
         do {
             standardPipelines.output.write(content: "\("ℹ︎".hexIfColoredTerminal(theme.primary, terminal)) \(message)\n")
 
-            try await action { progressMessage in
+            try await task { progressMessage in
                 standardPipelines.output
                     .write(content: "     \(progressMessage.hexIfColoredTerminal(theme.muted, terminal))\n")
             }
@@ -97,7 +97,7 @@ struct ProgressStep {
         // swiftlint:disable:next identifier_name
         do {
             render(message: lastMessage, icon: spinnerIcon ?? "ℹ︎")
-            try await action { progressMessage in
+            try await task { progressMessage in
                 lastMessage = progressMessage
                 render(message: lastMessage, icon: spinnerIcon ?? "ℹ︎")
             }

--- a/Sources/Noora/Components/ProgressStep.swift
+++ b/Sources/Noora/Components/ProgressStep.swift
@@ -126,11 +126,11 @@ struct ProgressStep {
     }
 
     static func completionMessage(_ message: String, timeString: String? = nil, theme: Theme, terminal: Terminaling) -> String {
-        "\("✔︎".hexIfColoredTerminal(theme.success, terminal)) \(message)\(" \(timeString ?? "")")"
+        "\("✔︎".hexIfColoredTerminal(theme.success, terminal)) \(message.hexIfColoredTerminal(theme.primary, terminal))\(" \(timeString ?? "")")"
     }
 
     static func errorMessage(_ message: String, timeString: String? = nil, theme: Theme, terminal: Terminaling) -> String {
-        "\("⨯".hexIfColoredTerminal(theme.danger, terminal)) \(message) \(timeString ?? "")"
+        "\("⨯".hexIfColoredTerminal(theme.danger, terminal)) \(message.hexIfColoredTerminal(theme.primary, terminal)) \(timeString ?? "")"
     }
 
     private func render(message: String, icon: String) {

--- a/Sources/Noora/Noora.swift
+++ b/Sources/Noora/Noora.swift
@@ -167,7 +167,7 @@ public protocol Noorable {
         title: TerminalText,
         successMessage: TerminalText?,
         errorMessage: TerminalText?,
-        action: @escaping (@escaping (TerminalText) -> Void) async throws -> Void
+        task: @escaping (@escaping (TerminalText) -> Void) async throws -> Void
     ) async throws
 }
 
@@ -303,14 +303,14 @@ public class Noora: Noorable {
         successMessage: String? = nil,
         errorMessage: String? = nil,
         showSpinner: Bool = true,
-        action: @escaping ((String) -> Void) async throws -> Void
+        task: @escaping (@escaping (String) -> Void) async throws -> Void
     ) async throws {
         let progressStep = ProgressStep(
             message: message,
             successMessage: successMessage,
             errorMessage: errorMessage,
             showSpinner: showSpinner,
-            action: action,
+            task: task,
             theme: theme,
             terminal: terminal,
             renderer: Renderer(),
@@ -419,13 +419,13 @@ extension Noorable {
         title: TerminalText,
         successMessage: TerminalText? = nil,
         errorMessage: TerminalText? = nil,
-        action: @escaping (@escaping (TerminalText) -> Void) async throws -> Void
+        task: @escaping (@escaping (TerminalText) -> Void) async throws -> Void
     ) async throws {
         try await collapsibleStep(
             title: title,
             successMessage: successMessage,
             errorMessage: errorMessage,
-            action: action
+            task: task
         )
     }
 }

--- a/Sources/Noora/Noora.swift
+++ b/Sources/Noora/Noora.swift
@@ -162,11 +162,13 @@ public protocol Noorable {
     ///   - title: A representative title of the underlying operation.
     ///   - successMessage: A message that's shown on success.
     ///   - errorMessage: A message that's shown on completion
-    ///   - action: The action to run.
+    ///   - visibleLines: The number of lines to show from the underlying task.
+    ///   - task: The task to run.
     func collapsibleStep(
         title: TerminalText,
         successMessage: TerminalText?,
         errorMessage: TerminalText?,
+        visibleLines: UInt,
         task: @escaping (@escaping (TerminalText) -> Void) async throws -> Void
     ) async throws
 }
@@ -323,7 +325,7 @@ public class Noora: Noorable {
         title: TerminalText,
         successMessage: TerminalText?,
         errorMessage: TerminalText?,
-        visibleLines: UInt = 3,
+        visibleLines: UInt,
         task: @escaping (@escaping (TerminalText) -> Void) async throws -> Void
     ) async throws {
         try await CollapsibleStep(
@@ -423,6 +425,7 @@ extension Noorable {
             title: title,
             successMessage: nil,
             errorMessage: nil,
+            visibleLines: 3,
             task: task
         )
     }

--- a/Sources/Noora/Noora.swift
+++ b/Sources/Noora/Noora.swift
@@ -146,14 +146,14 @@ public protocol Noorable {
     ///   - successMessage: The message that the step gets updated to when the action completes.
     ///   - errorMessage: The message that the step gets updated to when the action errors.
     ///   - showSpinner: True to show a spinner.
-    ///   - action: The asynchronous task to run. The caller can use the argument that the function takes to update the step
+    ///   - task: The asynchronous task to run. The caller can use the argument that the function takes to update the step
     /// message.
     func progressStep(
         message: String,
         successMessage: String?,
         errorMessage: String?,
         showSpinner: Bool,
-        action: @escaping ((String) -> Void) async throws -> Void
+        task: @escaping ((String) -> Void) async throws -> Void
     ) async throws
 
     /// A component to represent long-running operations showing the last lines of the sub-process,
@@ -302,10 +302,10 @@ public class Noora: Noorable {
 
     public func progressStep(
         message: String,
-        successMessage: String? = nil,
-        errorMessage: String? = nil,
-        showSpinner: Bool = true,
-        task: @escaping (@escaping (String) -> Void) async throws -> Void
+        successMessage: String?,
+        errorMessage: String?,
+        showSpinner: Bool,
+        task: @escaping ((String) -> Void) async throws -> Void
     ) async throws {
         let progressStep = ProgressStep(
             message: message,
@@ -403,17 +403,14 @@ extension Noorable {
 
     public func progressStep(
         message: String,
-        successMessage: String? = nil,
-        errorMessage: String? = nil,
-        showSpinner: Bool = true,
-        action: @escaping ((String) -> Void) async throws -> Void
+        task: @escaping ((String) -> Void) async throws -> Void
     ) async throws {
         try await progressStep(
             message: message,
-            successMessage: successMessage,
-            errorMessage: errorMessage,
-            showSpinner: showSpinner,
-            action: action
+            successMessage: nil,
+            errorMessage: nil,
+            showSpinner: true,
+            task: task
         )
     }
 

--- a/Sources/Noora/Noora.swift
+++ b/Sources/Noora/Noora.swift
@@ -167,7 +167,7 @@ public protocol Noorable {
         title: TerminalText,
         successMessage: TerminalText?,
         errorMessage: TerminalText?,
-        action: @escaping ((TerminalText) -> Void) async throws -> Void
+        action: @escaping (@escaping (TerminalText) -> Void) async throws -> Void
     ) async throws
 }
 
@@ -324,7 +324,7 @@ public class Noora: Noorable {
         successMessage: TerminalText?,
         errorMessage: TerminalText?,
         visibleLines: UInt = 3,
-        task: @escaping ((TerminalText) -> Void) async throws -> Void
+        task: @escaping (@escaping (TerminalText) -> Void) async throws -> Void
     ) async throws {
         try await CollapsibleStep(
             title: title,
@@ -419,7 +419,7 @@ extension Noorable {
         title: TerminalText,
         successMessage: TerminalText? = nil,
         errorMessage: TerminalText? = nil,
-        action: @escaping ((TerminalText) -> Void) async throws -> Void
+        action: @escaping (@escaping (TerminalText) -> Void) async throws -> Void
     ) async throws {
         try await collapsibleStep(
             title: title,

--- a/Sources/Noora/Noora.swift
+++ b/Sources/Noora/Noora.swift
@@ -417,14 +417,12 @@ extension Noorable {
 
     public func collapsibleStep(
         title: TerminalText,
-        successMessage: TerminalText? = nil,
-        errorMessage: TerminalText? = nil,
         task: @escaping (@escaping (TerminalText) -> Void) async throws -> Void
     ) async throws {
         try await collapsibleStep(
             title: title,
-            successMessage: successMessage,
-            errorMessage: errorMessage,
+            successMessage: nil,
+            errorMessage: nil,
             task: task
         )
     }

--- a/Sources/Noora/NooraMock.swift
+++ b/Sources/Noora/NooraMock.swift
@@ -121,6 +121,22 @@
             )
         }
 
+        public func collapsibleStep(
+            title: TerminalText,
+            successMessage: TerminalText?,
+            errorMessage: TerminalText?,
+            visibleLines: UInt,
+            task: @escaping (@escaping (TerminalText) -> Void) async throws -> Void
+        ) async throws {
+            try await noora.collapsibleStep(
+                title: title,
+                successMessage: successMessage,
+                errorMessage: errorMessage,
+                visibleLines: visibleLines,
+                task: task
+            )
+        }
+
         private class StandardPipelineEventsRecorder {
             var events: [StandardOutputEvent] = []
         }

--- a/Sources/Noora/NooraMock.swift
+++ b/Sources/Noora/NooraMock.swift
@@ -101,8 +101,8 @@
             noora.warning(alerts)
         }
 
-        public func progressStep(message: String, action: @escaping ((String) -> Void) async throws -> Void) async throws {
-            try await noora.progressStep(message: message, action: action)
+        public func progressStep(message: String, task: @escaping ((String) -> Void) async throws -> Void) async throws {
+            try await noora.progressStep(message: message, task: task)
         }
 
         public func progressStep(
@@ -110,14 +110,14 @@
             successMessage: String?,
             errorMessage: String?,
             showSpinner: Bool,
-            action: @escaping ((String) -> Void) async throws -> Void
+            task: @escaping ((String) -> Void) async throws -> Void
         ) async throws {
             try await noora.progressStep(
                 message: message,
                 successMessage: successMessage,
                 errorMessage: errorMessage,
                 showSpinner: showSpinner,
-                action: action
+                task: task
             )
         }
 

--- a/Sources/examples-cli/Commands/ProgressStepCommand.swift
+++ b/Sources/examples-cli/Commands/ProgressStepCommand.swift
@@ -12,21 +12,24 @@ struct ProgressStepCommand: AsyncParsableCommand {
         try await Noora().progressStep(
             message: "Loading manifests",
             successMessage: "Manifests loaded",
-            errorMessage: "Failed to load manifests"
+            errorMessage: "Failed to load manifests",
+            showSpinner: true
         ) { _ in
             try await Task.sleep(nanoseconds: 2_000_000_000)
         }
         try await Noora().progressStep(
             message: "Processing the graph",
             successMessage: "Project graph processed",
-            errorMessage: "Failed to process the project graph"
+            errorMessage: "Failed to process the project graph",
+            showSpinner: true
         ) { _ in
             try await Task.sleep(nanoseconds: 2_000_000_000)
         }
         try await Noora().progressStep(
             message: "Generating Xcode projects and workspace",
             successMessage: "Xcode projects and workspace generated",
-            errorMessage: "Failed to generate Xcode workspace and projects"
+            errorMessage: "Failed to generate Xcode workspace and projects",
+            showSpinner: true
         ) { _ in
             try await Task.sleep(nanoseconds: 2_000_000_000)
         }

--- a/Tests/NooraTests/Components/CollapsibleStepTests.swift
+++ b/Tests/NooraTests/Components/CollapsibleStepTests.swift
@@ -57,6 +57,42 @@ struct CollapsibleStepTests {
         """)
     }
 
+    @Test func run_whenInteractive_andLogsAreMultiline() async throws {
+        // Given
+        let terminal = MockTerminal(isInteractive: true, isColored: false)
+        let subject = CollapsibleStep(
+            title: "Authentication",
+            successMessage: "Authenticated",
+            errorMessage: "Authentication failed",
+            visibleLines: 3,
+            task: { log in
+                // Multiline
+                log("Redirecting to the browser\nPress CTRL+C to interrupt the process")
+            },
+            theme: .test(),
+            terminal: terminal,
+            renderer: renderer,
+            standardPipelines: StandardPipelines()
+        )
+
+        // When
+        try await subject.run()
+
+        // Then
+        var renders = Array(renderer.renders.reversed())
+        #expect(renders.popLast() == """
+        ◉ Authentication
+        """)
+        #expect(renders.popLast() == """
+        ◉ Authentication
+          Redirecting to the browser
+          Press CTRL+C to interrupt the process
+        """)
+        #expect(renders.popLast() == """
+        ✔︎ Authenticated 
+        """)
+    }
+
     @Test func run_whenNonInteractive() async throws {
         // Given
         let terminal = MockTerminal(isInteractive: false, isColored: false)

--- a/Tests/NooraTests/Components/ProgressStepTests.swift
+++ b/Tests/NooraTests/Components/ProgressStepTests.swift
@@ -21,7 +21,7 @@ struct ProgressStepTests {
             successMessage: "Project graph loaded",
             errorMessage: "Failed to load the project graph",
             showSpinner: true,
-            action: { reportProgress in
+            task: { reportProgress in
                 reportProgress("Loading project at path Project/")
             },
             theme: Theme.test(),
@@ -54,7 +54,7 @@ struct ProgressStepTests {
             successMessage: "Project graph loaded",
             errorMessage: "Failed to load the project graph",
             showSpinner: true,
-            action: { _ in
+            task: { _ in
                 throw error
             },
             theme: Theme.test(),
@@ -86,7 +86,7 @@ struct ProgressStepTests {
             successMessage: "Project graph loaded",
             errorMessage: "Failed to load the project graph",
             showSpinner: true,
-            action: { reportProgress in
+            task: { reportProgress in
                 reportProgress("Loading project at path Project/")
             },
             theme: Theme.test(),
@@ -117,7 +117,7 @@ struct ProgressStepTests {
             successMessage: "Project graph loaded",
             errorMessage: "Failed to load the project graph",
             showSpinner: true,
-            action: { _ in
+            task: { _ in
                 throw error
             },
             theme: Theme.test(),
@@ -147,7 +147,7 @@ struct ProgressStepTests {
             successMessage: "Project graph loaded",
             errorMessage: "Failed to load the project graph",
             showSpinner: false,
-            action: { reportProgress in
+            task: { reportProgress in
                 reportProgress("Loading project at path Project/")
             },
             theme: Theme.test(),
@@ -176,7 +176,7 @@ struct ProgressStepTests {
             successMessage: "Project graph loaded",
             errorMessage: "Failed to load the project graph",
             showSpinner: false,
-            action: { _ in
+            task: { _ in
                 throw error
             },
             theme: Theme.test(),

--- a/docs/content/components/step/progress.md
+++ b/docs/content/components/step/progress.md
@@ -51,4 +51,4 @@ try await Noora().progressStep(
 | `successMessage` | The message to show to the user when the step is successful | No | |
 | `errorMessage` | The message to show to the user when the step fails | No | |
 | `showSpinner` | Whether to show a spinner | No | `true` |
-| `action` | The action to execute | Yes | |
+| `task` | The task to execute | Yes | |


### PR DESCRIPTION
When I attempted to use the new collapsible component I noticed the closure passed to the `task` closure is non-escaping, limiting the flexibility of the caller. This PR fixes it.