### PR TITLE
fix: not include prefix for stdout lines recorded by the mock

### DIFF
--- a/Sources/Noora/NooraMock.swift
+++ b/Sources/Noora/NooraMock.swift
@@ -33,7 +33,13 @@
             standardPipelineEventsRecorder.events.map { event in
                 event.content.split(separator: "\n")
                     .map {
-                        "\(event.type): \($0)".trimmingCharacters(in: .whitespaces)
+                        switch event.type {
+                        case .error:
+                            "\(event.type): \($0)".trimmingCharacters(in: .whitespaces)
+                        case .output:
+                            $0.trimmingCharacters(in: .whitespaces)
+                        }
+
                     }.joined(separator: "\n")
             }.joined(separator: "\n")
         }

--- a/Tests/NooraTests/Utilities/NooraMockTests.swift
+++ b/Tests/NooraTests/Utilities/NooraMockTests.swift
@@ -1,0 +1,38 @@
+import Testing
+@testable import Noora
+
+struct NooraMockTests {
+    let subject = NooraMock()
+
+    @Test func prefixesLines_when_stderrMessages() {
+        // When
+        subject.error(.alert("Project not found", nextSteps: [
+            "Make sure the project exists in the server",
+        ]))
+
+        // Then
+        #expect(subject.description == """
+        stderr: ▌ ✖ Error
+        stderr: ▌ Project not found
+        stderr: ▌
+        stderr: ▌ Sorry this didn’t work. Here’s what to try next:
+        stderr: ▌  ▸ Make sure the project exists in the server
+        """)
+    }
+
+    @Test func doesntPrefixLines_when_stdOutMessages() {
+        // When
+        subject.success(.alert("Project set up successfully", nextSteps: [
+            "Build your project using 'tuist xcodebuild'",
+        ]))
+
+        // Then
+        #expect(subject.description == """
+        ▌ ✔ Success
+        ▌ Project set up successfully
+        ▌
+        ▌ Recommended next steps:
+        ▌  ▸ Build your project using 'tuist xcodebuild'
+        """)
+    }
+}


### PR DESCRIPTION
As discussed [here](https://github.com/tuist/tuist/pull/7334#discussion_r1963861334), I'm dropping the prefix when recording stdout events in `NooraMock`.