### PR TITLE
feat: scroll SingleChoicePrompt when larger than terminal height

### DIFF
--- a/Sources/Noora/Utilities/Terminal.swift
+++ b/Sources/Noora/Utilities/Terminal.swift
@@ -12,6 +12,12 @@ public protocol Terminaling {
     func withoutCursor(_ body: () throws -> Void) rethrows
     func inRawMode(_ body: @escaping () throws -> Void) rethrows
     func readCharacter() -> Character?
+    func size() -> TerminalSize?
+}
+
+public struct TerminalSize {
+    let rows: Int
+    let columns: Int
 }
 
 public struct Terminal: Terminaling {
@@ -84,6 +90,16 @@ public struct Terminal: Terminaling {
 
         tcsetattr(fileno(stdin), TCSANOW, &original) // Restore original settings
         return char != EOF ? Character(UnicodeScalar(UInt8(char))) : nil
+    }
+
+    /// Returns the size of the terminal if available.
+    public func size() -> TerminalSize? {
+        var w = winsize()
+        if ioctl(STDOUT_FILENO, UInt(TIOCGWINSZ), &w) == 0 {
+            return TerminalSize(rows: Int(w.ws_row), columns: Int(w.ws_col))
+        } else {
+            return nil
+        }
     }
 
     /// The function returns true when the terminal is interactive and false otherwise.

--- a/Tests/NooraTests/Components/SingleChoicePromptTests.swift
+++ b/Tests/NooraTests/Components/SingleChoicePromptTests.swift
@@ -14,7 +14,7 @@ struct SingleChoicePromptTests {
     }
 
     let renderer = MockRenderer()
-    let terminal = MockTerminal()
+    let terminal = MockTerminal(size: .init(rows: 10, columns: 80))
     let keyStrokeListener = MockKeyStrokeListener()
 
     @Test func renders_the_right_content() throws {
@@ -116,6 +116,60 @@ struct SingleChoicePromptTests {
         """)
         #expect(renders.popLast() == """
         ✔︎ How would you like to integrate Tuist?: option1 
+        """)
+    }
+
+    @Test func renders_the_right_content_when_more_options_than_terminal_height() throws {
+        // Given
+        let subject = SingleChoicePrompt(
+            title: nil,
+            question: "How would you like to integrate Tuist?",
+            description: nil,
+            theme: Theme.test(),
+            terminal: terminal,
+            collapseOnSelection: true,
+            renderer: renderer,
+            standardPipelines: StandardPipelines(),
+            keyStrokeListener: keyStrokeListener
+        )
+        keyStrokeListener.keyPressStub = .init(repeating: .downArrowKey, count: 20)
+
+        // When
+        _ = subject.run(options: (1 ... 20).map { "Option \($0)" })
+
+        // Then
+        #expect(renderer.renders[0] == """
+        How would you like to integrate Tuist?
+          ❯ Option 1
+            Option 2
+            Option 3
+            Option 4
+            Option 5
+            Option 6
+            Option 7
+        ↑/↓/k/j up/down • enter confirm
+        """)
+        #expect(renderer.renders[10] == """
+        How would you like to integrate Tuist?
+            Option 8
+            Option 9
+            Option 10
+          ❯ Option 11
+            Option 12
+            Option 13
+            Option 14
+        ↑/↓/k/j up/down • enter confirm
+        """)
+        #expect(renderer.renders[19] == """
+        How would you like to integrate Tuist?
+            Option 14
+            Option 15
+            Option 16
+            Option 17
+            Option 18
+            Option 19
+          ❯ Option 20
+        ↑/↓/k/j up/down • enter confirm
         """)
     }
 }

--- a/Tests/NooraTests/Mocks/MockTerminal.swift
+++ b/Tests/NooraTests/Mocks/MockTerminal.swift
@@ -3,13 +3,16 @@ import Noora
 class MockTerminal: Terminaling {
     var isInteractive: Bool = true
     var isColored: Bool = true
+    private var constantSize: TerminalSize? = nil
 
     init(
         isInteractive: Bool = true,
-        isColored: Bool = true
+        isColored: Bool = true,
+        size: TerminalSize? = nil
     ) {
         self.isInteractive = isInteractive
         self.isColored = isColored
+        constantSize = size
     }
 
     func inRawMode(_ body: @escaping () throws -> Void) rethrows {
@@ -23,5 +26,9 @@ class MockTerminal: Terminaling {
     var characters: [Character] = []
     func readCharacter() -> Character? {
         characters.removeFirst()
+    }
+
+    func size() -> TerminalSize? {
+        constantSize
     }
 }


### PR DESCRIPTION
Hi! Love the project, I'm hoping to retire [SwiftTUI](https://github.com/finnvoor/SwiftTUI) in favor of Noora for tools like [xcc](https://github.com/finnvoor/xcc). There's just a few things holding me back from switching, so here's a PR for one of them:

https://github.com/user-attachments/assets/21b8d0bd-2fac-4c4a-bc72-a2cbd2a721f7

When the number of options in SingleChoicePrompt exceeds the number of rows in your terminal, it will now render as a scrolling list.

Currently `Renderer` ends all renders with a newline. It would be nice if this was changed so the list could take the full terminal height, but I left this for a future PR to keep this one simple. Please let me know if you have any feedback!

Remaining:
- [x] Add tests