### PR TITLE
feat: add link support to terminal text

### DIFF
--- a/Sources/Noora/Utilities/TerminalText.swift
+++ b/Sources/Noora/Utilities/TerminalText.swift
@@ -9,7 +9,8 @@ public struct TerminalText: Equatable, Hashable {
         case raw(String)
         /// A string that represents a system command (e.g. 'tuist generate')
         case command(String)
-
+        /// Use this component to format links.
+        case link(title: String, href: String)
         /// A string with the theme's primary color
         case primary(String)
         /// A string with the theme's secondary color
@@ -32,6 +33,7 @@ public struct TerminalText: Equatable, Hashable {
             switch component {
             case let .raw(rawString): rawString
             case let .command(command): "'\(command)'".hexIfColoredTerminal(theme.secondary, terminal)
+            case let .link(title, href): "\u{1B}]8;;\(href)\u{1B}\\\(title.hexIfColoredTerminal(theme.secondary, terminal))\u{1B}]8;;\u{1B}\\"
             case let .primary(primary): primary.hexIfColoredTerminal(theme.primary, terminal)
             case let .secondary(secondary): secondary.hexIfColoredTerminal(theme.secondary, terminal)
             case let .muted(muted): muted.hexIfColoredTerminal(theme.muted, terminal)

--- a/Sources/examples-cli/Commands/FormatCommand.swift
+++ b/Sources/examples-cli/Commands/FormatCommand.swift
@@ -11,7 +11,8 @@ struct FormatCommand: AsyncParsableCommand {
     func run() async throws {
         let terminalText = TerminalText("""
         \(.raw("A string with no special semantics in the context of terminal text."))
-        \(.command("a-string-that-represents-a-system-command"))
+        \(.command("a-string-that-represents-a-system-command")),
+        \(.link(title: "Tuist website", href: "https://tuist.dev"))
         \(.primary("A string with the theme's primary color"))
         \(.secondary("A string with the theme's secondary color"))
         \(.muted("A string with the theme's muted color"))


### PR DESCRIPTION
[Modern terminal emulators](https://github.com/Alhadis/OSC8-Adoption/) support links alà web. This PR adds support for it.

> [!NOTE]
> We don't check wether the terminal emulator supports it, which would be a bit tricky, but given the above list, I'd expect the links to work for most people.

(Note the "Tuist website" below)
<img width="566" alt="image" src="https://github.com/user-attachments/assets/9c3ecaaa-9959-4ab1-a4e8-fd1e8c79eca8" />
