### PR TITLE
feat: make `KeyStrokeListener` public

### DIFF
--- a/Sources/Noora/Utilities/KeyStrokeListener.swift
+++ b/Sources/Noora/Utilities/KeyStrokeListener.swift
@@ -52,6 +52,8 @@ public protocol KeyStrokeListening {
 public struct KeyStrokeListener: KeyStrokeListening {
     private var buffer = ""
 
+    public init() {}
+
     public func listen(terminal: Terminaling, onKeyPress: @escaping (KeyStroke) -> OnKeyPressResult) {
         var buffer = ""
 
@@ -85,5 +87,13 @@ public struct KeyStrokeListener: KeyStrokeListening {
                 buffer = ""
             }
         }
+    }
+}
+
+extension KeyStrokeListening {
+    /// Listens for key-strokes notifying the caller by calling the given closure.
+    /// - Parameter onKeyPress: Closure to receive key press notifications.
+    public func listen(onKeyPress: @escaping (KeyStroke) -> OnKeyPressResult) {
+        listen(terminal: Terminal(), onKeyPress: onKeyPress)
     }
 }

--- a/docs/.vitepress/config.mjs
+++ b/docs/.vitepress/config.mjs
@@ -104,6 +104,15 @@ export default defineConfig({
           },
         ],
       },
+      {
+        text: "Utilities",
+        items: [
+          {
+            text: "Keystroke listener",
+            link: "/utilities/keystroke-listener",
+          },
+        ],
+      },
     ],
 
     socialLinks: [

--- a/docs/content/utilities/keystroke-listener.md
+++ b/docs/content/utilities/keystroke-listener.md
@@ -1,0 +1,21 @@
+---
+title: Keystroke listener
+titleTemplate: ":title · Utilities · Noora · Tuist"
+description: A utility to listen for keystrokes.
+---
+
+# Keystroke listener
+
+When building a CLI, you might need to observe keystrokes,
+for example to execute an action as a response to a key press (e.g. before taking the user to the browser for authentication).
+
+Noora provides a utility, `KeyStrokeListener`, which you can use for that:
+
+```swift
+let keystrokeListener = KeyStrokeListener()
+keystrokeListener.listen { key in
+  case key {
+    // Match the key you are interested in.
+  }
+}
+```


### PR DESCRIPTION
As part of building the new get started experience, where I reused the login service, I noticed we ended up taking the user to the browser without any context. A better experience would consist of asking the user to press "enter" after reading that we are going to take them to the browser to complete the authentication.

Since we have the utility in Noora to listen to keystrokes, I'm making it public and documenting it for anyone to use.