### PR TITLE
feat: add autoSelectSingle option to SingleChoicePrompt

### DIFF
--- a/Sources/Noora/Components/SingleChoicePrompt.swift
+++ b/Sources/Noora/Components/SingleChoicePrompt.swift
@@ -20,6 +20,7 @@ struct SingleChoicePrompt {
     let terminal: Terminaling
     let collapseOnSelection: Bool
     let filterMode: SingleChoicePromptFilterMode
+    let autoselectSingleChoice: Bool
     let renderer: Rendering
     let standardPipelines: StandardPipelines
     let keyStrokeListener: KeyStrokeListening
@@ -35,6 +36,11 @@ struct SingleChoicePrompt {
     // MARK: - Private
 
     private func run<T: Equatable>(options: [(T, String)]) -> T {
+        if autoselectSingleChoice, options.count == 1 {
+            renderResult(selectedOption: options[0])
+            return options[0].0
+        }
+
         if !terminal.isInteractive {
             fatalError("'\(question)' can't be prompted in a non-interactive session.")
         }

--- a/Sources/Noora/Noora.swift
+++ b/Sources/Noora/Noora.swift
@@ -68,6 +68,8 @@ public protocol Noorable {
     ///   - description: Use it to add some explanation to what the question is for.
     ///   - collapseOnSelection: Whether the prompt should collapse after the user selects an option.
     ///   - filterMode: Whether filtering should be disabled, toggleable, or enabled.
+    ///   - autoselectSingleChoice: Whether the prompt should automatically select the first item when options only contains one
+    /// item.
     /// - Returns: The option selected by the user.
     func singleChoicePrompt<T: Equatable & CustomStringConvertible>(
         title: TerminalText?,
@@ -75,7 +77,8 @@ public protocol Noorable {
         options: [T],
         description: TerminalText?,
         collapseOnSelection: Bool,
-        filterMode: SingleChoicePromptFilterMode
+        filterMode: SingleChoicePromptFilterMode,
+        autoselectSingleChoice: Bool
     ) -> T
 
     /// It shows multiple options to the user to select one.
@@ -85,13 +88,16 @@ public protocol Noorable {
     ///   - description: Use it to add some explanation to what the question is for.
     ///   - collapseOnSelection: Whether the prompt should collapse after the user selects an option.
     ///   - filterMode: Whether filtering should be disabled, toggleable, or enabled.
+    ///   - autoselectSingleChoice: Whether the prompt should automatically select the first item when options only contains one
+    /// item.
     /// - Returns: The option selected by the user.
     func singleChoicePrompt<T: CaseIterable & CustomStringConvertible & Equatable>(
         title: TerminalText?,
         question: TerminalText,
         description: TerminalText?,
         collapseOnSelection: Bool,
-        filterMode: SingleChoicePromptFilterMode
+        filterMode: SingleChoicePromptFilterMode,
+        autoselectSingleChoice: Bool
     ) -> T
 
     /// It shows a component to answer yes or no to a question.
@@ -209,7 +215,8 @@ public class Noora: Noorable {
         options: [T],
         description: TerminalText?,
         collapseOnSelection: Bool,
-        filterMode: SingleChoicePromptFilterMode
+        filterMode: SingleChoicePromptFilterMode,
+        autoselectSingleChoice: Bool
     ) -> T where T: CustomStringConvertible, T: Equatable {
         let component = SingleChoicePrompt(
             title: title,
@@ -219,6 +226,7 @@ public class Noora: Noorable {
             terminal: terminal,
             collapseOnSelection: collapseOnSelection,
             filterMode: filterMode,
+            autoselectSingleChoice: autoselectSingleChoice,
             renderer: renderer,
             standardPipelines: standardPipelines,
             keyStrokeListener: keyStrokeListener
@@ -231,7 +239,8 @@ public class Noora: Noorable {
         question: TerminalText,
         description: TerminalText? = nil,
         collapseOnSelection: Bool = true,
-        filterMode: SingleChoicePromptFilterMode = .disabled
+        filterMode: SingleChoicePromptFilterMode = .disabled,
+        autoselectSingleChoice: Bool = true
     ) -> T {
         let component = SingleChoicePrompt(
             title: title,
@@ -241,6 +250,7 @@ public class Noora: Noorable {
             terminal: terminal,
             collapseOnSelection: collapseOnSelection,
             filterMode: filterMode,
+            autoselectSingleChoice: autoselectSingleChoice,
             renderer: renderer,
             standardPipelines: standardPipelines,
             keyStrokeListener: keyStrokeListener
@@ -372,7 +382,8 @@ extension Noorable {
         options: [T],
         description: TerminalText? = nil,
         collapseOnSelection: Bool = true,
-        filterMode: SingleChoicePromptFilterMode = .disabled
+        filterMode: SingleChoicePromptFilterMode = .disabled,
+        autoselectSingleChoice: Bool = true
     ) -> T {
         singleChoicePrompt(
             title: title,
@@ -380,7 +391,8 @@ extension Noorable {
             options: options,
             description: description,
             collapseOnSelection: collapseOnSelection,
-            filterMode: filterMode
+            filterMode: filterMode,
+            autoselectSingleChoice: autoselectSingleChoice
         )
     }
 
@@ -389,14 +401,16 @@ extension Noorable {
         question: TerminalText,
         description: TerminalText? = nil,
         collapseOnSelection: Bool = true,
-        filterMode: SingleChoicePromptFilterMode = .disabled
+        filterMode: SingleChoicePromptFilterMode = .disabled,
+        autoselectSingleChoice: Bool = true
     ) -> T {
         singleChoicePrompt(
             title: title,
             question: question,
             description: description,
             collapseOnSelection: collapseOnSelection,
-            filterMode: filterMode
+            filterMode: filterMode,
+            autoselectSingleChoice: autoselectSingleChoice
         )
     }
 

--- a/Tests/NooraTests/Components/SingleChoicePromptTests.swift
+++ b/Tests/NooraTests/Components/SingleChoicePromptTests.swift
@@ -27,6 +27,7 @@ struct SingleChoicePromptTests {
             terminal: terminal,
             collapseOnSelection: true,
             filterMode: .toggleable,
+            autoselectSingleChoice: false,
             renderer: renderer,
             standardPipelines: StandardPipelines(),
             keyStrokeListener: keyStrokeListener
@@ -81,6 +82,7 @@ struct SingleChoicePromptTests {
             terminal: terminal,
             collapseOnSelection: true,
             filterMode: .toggleable,
+            autoselectSingleChoice: false,
             renderer: renderer,
             standardPipelines: StandardPipelines(),
             keyStrokeListener: keyStrokeListener
@@ -131,6 +133,7 @@ struct SingleChoicePromptTests {
             terminal: terminal,
             collapseOnSelection: true,
             filterMode: .toggleable,
+            autoselectSingleChoice: false,
             renderer: renderer,
             standardPipelines: StandardPipelines(),
             keyStrokeListener: keyStrokeListener
@@ -175,6 +178,7 @@ struct SingleChoicePromptTests {
             terminal: terminal,
             collapseOnSelection: true,
             filterMode: .toggleable,
+            autoselectSingleChoice: false,
             renderer: renderer,
             standardPipelines: StandardPipelines(),
             keyStrokeListener: keyStrokeListener
@@ -243,5 +247,30 @@ struct SingleChoicePromptTests {
             adipiscing
         ↑/↓/k/j up/down • / filter • enter confirm
         """)
+    }
+
+    @Test func auto_selects_single_item() throws {
+        // Given
+        let subject = SingleChoicePrompt(
+            title: nil,
+            question: "How would you like to integrate Tuist?",
+            description: nil,
+            theme: Theme.test(),
+            terminal: terminal,
+            collapseOnSelection: true,
+            filterMode: .toggleable,
+            autoselectSingleChoice: true,
+            renderer: renderer,
+            standardPipelines: StandardPipelines(),
+            keyStrokeListener: keyStrokeListener
+        )
+        keyStrokeListener.keyPressStub = []
+
+        // When
+        let selectedItem = subject.run(options: ["single"])
+
+        // Then
+        #expect(selectedItem == "single")
+        #expect(renderer.renders == ["✔︎ How would you like to integrate Tuist?: single "])
     }
 }

--- a/docs/content/components/prompts/single-choice.md
+++ b/docs/content/components/prompts/single-choice.md
@@ -74,3 +74,4 @@ let selectedOption = Noora().singleChoicePrompt(
 | `description` | A description that provides more context about the question. | No | |
 | `collapseOnSelection` | Whether the prompt should collapse after the user selects an option. | No | `true` |
 | `filterMode` | Whether the list of options should be filterable. | No | `disabled` |
+| `autoselectSingleChoice` | Whether the prompt should automatically select the first item when options only contains one item. | No | `true` |


### PR DESCRIPTION
Adds an option `autoSelectSingle` that, when enabled, automatically picks the first item from options when options only contains one item, skipping the wait for user selection.

This is something I use in `xcc`, and the benefit over just handling this in `xcc` is that the output is still rendered in the SingleChoicePrompt style, making the output consistent whether an option is manually selected or auto selected.

Example: The `main` branch is auto selected

https://github.com/user-attachments/assets/b150f0f0-4eba-4140-bc60-d3c302c17f8b

