### PR TITLE
feat: allow custom renderer and keystroke listener in Noora

### DIFF
--- a/Sources/Noora/Noora.swift
+++ b/Sources/Noora/Noora.swift
@@ -182,15 +182,21 @@ public class Noora: Noorable {
     let standardPipelines: StandardPipelines
     let theme: Theme
     let terminal: Terminaling
+    let renderer: Rendering
+    let keyStrokeListener: KeyStrokeListening
 
     public init(
         theme: Theme = .default,
         terminal: Terminaling = Terminal(),
-        standardPipelines: StandardPipelines = StandardPipelines()
+        standardPipelines: StandardPipelines = StandardPipelines(),
+        renderer: Rendering = Renderer(),
+        keyStrokeListener: KeyStrokeListening = KeyStrokeListener()
     ) {
         self.theme = theme
         self.terminal = terminal
         self.standardPipelines = standardPipelines
+        self.renderer = renderer
+        self.keyStrokeListener = keyStrokeListener
     }
 
     public func singleChoicePrompt<T>(
@@ -209,9 +215,9 @@ public class Noora: Noorable {
             terminal: terminal,
             collapseOnSelection: collapseOnSelection,
             filterMode: filterMode,
-            renderer: Renderer(),
-            standardPipelines: StandardPipelines(),
-            keyStrokeListener: KeyStrokeListener()
+            renderer: renderer,
+            standardPipelines: standardPipelines,
+            keyStrokeListener: keyStrokeListener
         )
         return component.run(options: options)
     }
@@ -231,9 +237,9 @@ public class Noora: Noorable {
             terminal: terminal,
             collapseOnSelection: collapseOnSelection,
             filterMode: filterMode,
-            renderer: Renderer(),
+            renderer: renderer,
             standardPipelines: standardPipelines,
-            keyStrokeListener: KeyStrokeListener()
+            keyStrokeListener: keyStrokeListener
         )
         return component.run()
     }
@@ -251,8 +257,8 @@ public class Noora: Noorable {
             theme: theme,
             terminal: terminal,
             collapseOnAnswer: collapseOnAnswer,
-            renderer: Renderer(),
-            standardPipelines: StandardPipelines()
+            renderer: renderer,
+            standardPipelines: standardPipelines
         )
         return component.run()
     }
@@ -271,9 +277,9 @@ public class Noora: Noorable {
             theme: theme,
             terminal: terminal,
             collapseOnSelection: collapseOnSelection,
-            renderer: Renderer(),
+            renderer: renderer,
             standardPipelines: standardPipelines,
-            keyStrokeListener: KeyStrokeListener(),
+            keyStrokeListener: keyStrokeListener,
             defaultAnswer: defaultAnswer
         ).run()
     }
@@ -324,7 +330,7 @@ public class Noora: Noorable {
             task: task,
             theme: theme,
             terminal: terminal,
-            renderer: Renderer(),
+            renderer: renderer,
             standardPipelines: standardPipelines
         )
         try await progressStep.run()
@@ -345,8 +351,8 @@ public class Noora: Noorable {
             task: task,
             theme: theme,
             terminal: terminal,
-            renderer: Renderer(),
-            standardPipelines: StandardPipelines()
+            renderer: renderer,
+            standardPipelines: standardPipelines
         ).run()
     }
 

--- a/Sources/Noora/Utilities/Renderer.swift
+++ b/Sources/Noora/Utilities/Renderer.swift
@@ -17,7 +17,7 @@ public protocol Rendering: AnyObject {
 public class Renderer: Rendering {
     private var lastRenderedContent: [String] = []
 
-    init() {}
+    public init() {}
 
     private func eraseLines(_ lines: Int, standardPipeline: StandardPipelining) {
         if lines == 0 { return }

--- a/mise/tasks/test-linux
+++ b/mise/tasks/test-linux
@@ -7,4 +7,4 @@ podman run --rm \
     --workdir "/package" \
     swift:6.0.0 \
     /bin/bash -c \
-    "swift test --configuration release --build-path ./.build/linux"
+    "swift test --build-path ./.build/linux"


### PR DESCRIPTION
Allow passing a custom `Rendering`/`KeyStrokeListening` to `Noora`, enabling amazing things like [this](https://mastodon.social/@finnvoorhees/114072798657337663).