### PR TITLE
fix: add .returnKey again to KeystrokeListener

### DIFF
--- a/Sources/Noora/Utilities/KeyStrokeListener.swift
+++ b/Sources/Noora/Utilities/KeyStrokeListener.swift
@@ -2,6 +2,8 @@ import Foundation
 
 /// An enum that represents the key strokes supported by the `KeyStrokeListening`
 public enum KeyStroke {
+    /// It represents the return key.
+    case returnKey
     /// It represents a printable character key
     case printable(Character)
     /// It represents the up arrow
@@ -61,6 +63,7 @@ public struct KeyStrokeListener: KeyStrokeListening {
 
             let keyStroke: KeyStroke? = switch (char, buffer) {
             case let (char, _) where buffer.count == 1 && char.isPrintable: .printable(char)
+            case let (char, _) where char == "\n": .returnKey
             case (_, "\u{1B}[A"): .upArrowKey
             case (_, "\u{1B}[B"): .downArrowKey
             case (_, "\u{1B}[C"): .rightArrowKey


### PR DESCRIPTION
I noticed we [removed](https://github.com/tuist/Noora/pull/195/files#diff-3ffbad14a9742d827b87af4b4fcf1c29e883423212e9b7dad4c35f8270036576) `.returnKey` as a keystroke from `KeystrokeListener` (maybe by mistake?), so I'm adding it back. 