### PR TITLE
fix: component overriding previous renders

### DIFF
--- a/Sources/Noora/Noora.swift
+++ b/Sources/Noora/Noora.swift
@@ -193,7 +193,6 @@ public class Noora: Noorable {
     let standardPipelines: StandardPipelines
     let theme: Theme
     let terminal: Terminaling
-    let renderer: Rendering
     let keyStrokeListener: KeyStrokeListening
     let logger: Logger?
 
@@ -201,14 +200,13 @@ public class Noora: Noorable {
         theme: Theme = .default,
         terminal: Terminaling = Terminal(),
         standardPipelines: StandardPipelines = StandardPipelines(),
-        renderer: Rendering = Renderer(),
+        renderer _: Rendering = Renderer(),
         keyStrokeListener: KeyStrokeListening = KeyStrokeListener(),
         logger: Logger? = nil
     ) {
         self.theme = theme
         self.terminal = terminal
         self.standardPipelines = standardPipelines
-        self.renderer = renderer
         self.keyStrokeListener = keyStrokeListener
         self.logger = logger
     }
@@ -231,7 +229,7 @@ public class Noora: Noorable {
             collapseOnSelection: collapseOnSelection,
             filterMode: filterMode,
             autoselectSingleChoice: autoselectSingleChoice,
-            renderer: renderer,
+            renderer: Renderer(),
             standardPipelines: standardPipelines,
             keyStrokeListener: keyStrokeListener,
             logger: logger
@@ -256,7 +254,7 @@ public class Noora: Noorable {
             collapseOnSelection: collapseOnSelection,
             filterMode: filterMode,
             autoselectSingleChoice: autoselectSingleChoice,
-            renderer: renderer,
+            renderer: Renderer(),
             standardPipelines: standardPipelines,
             keyStrokeListener: keyStrokeListener,
             logger: logger
@@ -277,7 +275,7 @@ public class Noora: Noorable {
             theme: theme,
             terminal: terminal,
             collapseOnAnswer: collapseOnAnswer,
-            renderer: renderer,
+            renderer: Renderer(),
             standardPipelines: standardPipelines,
             logger: logger
         )
@@ -298,7 +296,7 @@ public class Noora: Noorable {
             theme: theme,
             terminal: terminal,
             collapseOnSelection: collapseOnSelection,
-            renderer: renderer,
+            renderer: Renderer(),
             standardPipelines: standardPipelines,
             keyStrokeListener: keyStrokeListener,
             defaultAnswer: defaultAnswer,
@@ -355,7 +353,7 @@ public class Noora: Noorable {
             task: task,
             theme: theme,
             terminal: terminal,
-            renderer: renderer,
+            renderer: Renderer(),
             standardPipelines: standardPipelines,
             logger: logger
         )
@@ -377,7 +375,7 @@ public class Noora: Noorable {
             task: task,
             theme: theme,
             terminal: terminal,
-            renderer: renderer,
+            renderer: Renderer(),
             standardPipelines: standardPipelines,
             logger: logger
         ).run()

--- a/Sources/Noora/NooraMock.swift
+++ b/Sources/Noora/NooraMock.swift
@@ -117,6 +117,7 @@
             successMessage: String?,
             errorMessage: String?,
             showSpinner: Bool,
+            renderer: Rendering,
             task: @escaping ((String) -> Void) async throws -> Void
         ) async throws {
             try await noora.progressStep(
@@ -124,6 +125,7 @@
                 successMessage: successMessage,
                 errorMessage: errorMessage,
                 showSpinner: showSpinner,
+                renderer: renderer,
                 task: task
             )
         }
@@ -133,6 +135,7 @@
             successMessage: TerminalText?,
             errorMessage: TerminalText?,
             visibleLines: UInt,
+            renderer: Rendering,
             task: @escaping (@escaping (TerminalText) -> Void) async throws -> Void
         ) async throws {
             try await noora.collapsibleStep(
@@ -140,6 +143,7 @@
                 successMessage: successMessage,
                 errorMessage: errorMessage,
                 visibleLines: visibleLines,
+                renderer: renderer,
                 task: task
             )
         }


### PR DESCRIPTION
In a recent PR we scoped the lifecycle of `Renderer` to the lifecycle of `Noora`, and that caused the rendering of components to override previous renders. `Renderer` was designed to have its lifetime scope to every component, and therefore we should be creating a new instance for every render. This PR fixes it.