### PR TITLE
fix: too strong selection color in the yes-no component when used with light terminal themes 

### DIFF
--- a/Sources/Noora/Components/YesOrNoChoicePrompt.swift
+++ b/Sources/Noora/Components/YesOrNoChoicePrompt.swift
@@ -88,7 +88,7 @@ struct YesOrNoChoicePrompt {
 
         let yes = if answer {
             if terminal.isColored {
-                " Yes (y) ".onHex(theme.muted)
+                " Yes (y) ".onHex(theme.secondary)
             } else {
                 "[ Yes (y) ]"
             }
@@ -100,7 +100,7 @@ struct YesOrNoChoicePrompt {
             " No (n) "
         } else {
             if terminal.isColored {
-                " No (n) ".onHex(theme.muted)
+                " No (n) ".onHex(theme.secondary)
             } else {
                 "[ No (n) ]"
             }


### PR DESCRIPTION
As reported by @fortmarek [here](https://github.com/tuist/tuist/pull/7355), the selection color in the yes/no component looks too dark with a light theme:

![image](https://github.com/user-attachments/assets/36007f52-9300-44aa-8ead-e04f3a99c882)

I adjusted it to use the secondary color instead:

### Light
<img width="584" alt="image" src="https://github.com/user-attachments/assets/8ff2d206-8f83-4d67-b434-394f3ab64b54" />

### Dark

<img width="619" alt="image" src="https://github.com/user-attachments/assets/9bfe93e0-c5b3-4f7e-b9e4-42284d13e050" />

> [!NOTE]
> Reading the background color of the terminal and fining colors with enough contrast is technically feasible, however, I don't think it's worth the effort at the moment. Instead, we can pick colors that have good contrast with dark and light colors.

