### PR TITLE
fix: improve contrast of secondary, accent, and success colors in the default theme.

### DIFF
--- a/Sources/Noora/Theme.swift
+++ b/Sources/Noora/Theme.swift
@@ -10,7 +10,7 @@ public struct Theme {
         muted: "505050",
         accent: "FFFC67",
         danger: "FF2929",
-        success: "89F94F"
+        success: "56822B"
     )
 
     /// A primary color–it should represent the brand.

--- a/Sources/Noora/Theme.swift
+++ b/Sources/Noora/Theme.swift
@@ -6,7 +6,7 @@ public struct Theme {
     /// Noora's default theme.
     public static var `default` = Theme(
         primary: "A378F2",
-        secondary: "FF8EC6",
+        secondary: "FF4081",
         muted: "505050",
         accent: "AC6115",
         danger: "FF2929",

--- a/Sources/Noora/Theme.swift
+++ b/Sources/Noora/Theme.swift
@@ -8,7 +8,7 @@ public struct Theme {
         primary: "A378F2",
         secondary: "FF8EC6",
         muted: "505050",
-        accent: "FFFC67",
+        accent: "AC6115",
         danger: "FF2929",
         success: "56822B"
     )


### PR DESCRIPTION
I picked those colors using a dark background as a reference and they turned out to have a terrible contract in light themes. This PR changes the `secondary`, `accent`, and `success` colors of the main theme to have a good contrast in dark and light backgrounds.