### PR TITLE
fix: recursion in the extension to render single choice prompt component

### DIFF
--- a/Sources/Noora/Noora.swift
+++ b/Sources/Noora/Noora.swift
@@ -71,6 +71,7 @@ public protocol Noorable {
     ///   - filterMode: Whether filtering should be disabled, toggleable, or enabled.
     ///   - autoselectSingleChoice: Whether the prompt should automatically select the first item when options only contains one
     /// item.
+    ///   - renderer: A rendering interface that holds the UI state.
     /// - Returns: The option selected by the user.
     func singleChoicePrompt<T: Equatable & CustomStringConvertible>(
         title: TerminalText?,
@@ -79,7 +80,8 @@ public protocol Noorable {
         description: TerminalText?,
         collapseOnSelection: Bool,
         filterMode: SingleChoicePromptFilterMode,
-        autoselectSingleChoice: Bool
+        autoselectSingleChoice: Bool,
+        renderer: Rendering
     ) -> T
 
     /// It shows multiple options to the user to select one.
@@ -91,6 +93,7 @@ public protocol Noorable {
     ///   - filterMode: Whether filtering should be disabled, toggleable, or enabled.
     ///   - autoselectSingleChoice: Whether the prompt should automatically select the first item when options only contains one
     /// item.
+    ///   - renderer: A rendering interface that holds the UI state.
     /// - Returns: The option selected by the user.
     func singleChoicePrompt<T: CaseIterable & CustomStringConvertible & Equatable>(
         title: TerminalText?,
@@ -98,7 +101,8 @@ public protocol Noorable {
         description: TerminalText?,
         collapseOnSelection: Bool,
         filterMode: SingleChoicePromptFilterMode,
-        autoselectSingleChoice: Bool
+        autoselectSingleChoice: Bool,
+        renderer: Rendering
     ) -> T
 
     /// It shows a component to answer yes or no to a question.
@@ -242,12 +246,12 @@ public class Noora: Noorable {
     }
 
     public func singleChoicePrompt<T: CaseIterable & CustomStringConvertible & Equatable>(
-        title: TerminalText? = nil,
+        title: TerminalText?,
         question: TerminalText,
-        description: TerminalText? = nil,
-        collapseOnSelection: Bool = true,
-        filterMode: SingleChoicePromptFilterMode = .disabled,
-        autoselectSingleChoice: Bool = true,
+        description: TerminalText?,
+        collapseOnSelection: Bool,
+        filterMode: SingleChoicePromptFilterMode,
+        autoselectSingleChoice: Bool,
         renderer: Rendering
     ) -> T {
         let component = SingleChoicePrompt(
@@ -396,15 +400,16 @@ public class Noora: Noorable {
 }
 
 extension Noorable {
-    public func singleChoicePrompt<T: Equatable & CustomStringConvertible>(
+    public func singleChoicePrompt<T>(
         title: TerminalText? = nil,
         question: TerminalText,
         options: [T],
         description: TerminalText? = nil,
         collapseOnSelection: Bool = true,
         filterMode: SingleChoicePromptFilterMode = .disabled,
-        autoselectSingleChoice: Bool = true
-    ) -> T {
+        autoselectSingleChoice: Bool = true,
+        renderer: Rendering = Renderer()
+    ) -> T where T: CustomStringConvertible, T: Equatable {
         singleChoicePrompt(
             title: title,
             question: question,
@@ -412,7 +417,8 @@ extension Noorable {
             description: description,
             collapseOnSelection: collapseOnSelection,
             filterMode: filterMode,
-            autoselectSingleChoice: autoselectSingleChoice
+            autoselectSingleChoice: autoselectSingleChoice,
+            renderer: renderer
         )
     }
 
@@ -422,7 +428,8 @@ extension Noorable {
         description: TerminalText? = nil,
         collapseOnSelection: Bool = true,
         filterMode: SingleChoicePromptFilterMode = .disabled,
-        autoselectSingleChoice: Bool = true
+        autoselectSingleChoice: Bool = true,
+        renderer: Rendering = Renderer()
     ) -> T {
         singleChoicePrompt(
             title: title,
@@ -430,7 +437,8 @@ extension Noorable {
             description: description,
             collapseOnSelection: collapseOnSelection,
             filterMode: filterMode,
-            autoselectSingleChoice: autoselectSingleChoice
+            autoselectSingleChoice: autoselectSingleChoice,
+            renderer: renderer
         )
     }
 

--- a/Sources/Noora/NooraMock.swift
+++ b/Sources/Noora/NooraMock.swift
@@ -52,23 +52,45 @@
             ))
         }
 
-        public func singleChoicePrompt<T>(question: TerminalText) -> T where T: CaseIterable, T: CustomStringConvertible,
-            T: Equatable
-        {
-            noora.singleChoicePrompt(question: question)
+        public func singleChoicePrompt<T>(
+            title: TerminalText?,
+            question: TerminalText,
+            options: [T],
+            description: TerminalText?,
+            collapseOnSelection: Bool,
+            filterMode: SingleChoicePromptFilterMode,
+            autoselectSingleChoice: Bool,
+            renderer: any Rendering
+        ) -> T where T: CustomStringConvertible, T: Equatable {
+            noora.singleChoicePrompt(
+                title: title,
+                question: question,
+                options: options,
+                description: description,
+                collapseOnSelection: collapseOnSelection,
+                filterMode: filterMode,
+                autoselectSingleChoice: autoselectSingleChoice,
+                renderer: renderer
+            )
         }
 
         public func singleChoicePrompt<T>(
             title: TerminalText?,
             question: TerminalText,
             description: TerminalText?,
-            collapseOnSelection: Bool
+            collapseOnSelection: Bool,
+            filterMode: SingleChoicePromptFilterMode,
+            autoselectSingleChoice: Bool,
+            renderer: any Rendering
         ) -> T where T: CaseIterable, T: CustomStringConvertible, T: Equatable {
             noora.singleChoicePrompt(
                 title: title,
                 question: question,
                 description: description,
-                collapseOnSelection: collapseOnSelection
+                collapseOnSelection: collapseOnSelection,
+                filterMode: filterMode,
+                autoselectSingleChoice: autoselectSingleChoice,
+                renderer: renderer
             )
         }
 

--- a/Tests/NooraTests/Components/SingleChoicePromptTests.swift
+++ b/Tests/NooraTests/Components/SingleChoicePromptTests.swift
@@ -128,6 +128,7 @@ struct SingleChoicePromptTests {
 
     @Test func renders_the_right_content_when_more_options_than_terminal_height() throws {
         // Given
+        let terminal = MockTerminal(isColored: false, size: .init(rows: 10, columns: 80))
         let subject = SingleChoicePrompt(
             title: nil,
             question: "How would you like to integrate Tuist?",

--- a/Tests/NooraTests/Utilities/TerminalTextTests.swift
+++ b/Tests/NooraTests/Utilities/TerminalTextTests.swift
@@ -46,13 +46,13 @@ struct TerminalTextTests {
         // Then
         #expect(formattedText == """
         A string with no special semantics in the context of terminal text.
-        \u{1B}[38;5;218m'a-string-that-represents-a-system-command'\u{1B}[0m
+        \u{1B}[38;5;205m'a-string-that-represents-a-system-command'\u{1B}[0m
         \u{1B}[38;5;141mA string with the theme's primary color\u{1B}[0m
-        \u{1B}[38;5;218mA string with the theme's secondary color\u{1B}[0m
+        \u{1B}[38;5;205mA string with the theme's secondary color\u{1B}[0m
         \u{1B}[38;5;59mA string with the theme's muted color\u{1B}[0m
-        \u{1B}[38;5;228mA string with the theme's accent color\u{1B}[0m
+        \u{1B}[38;5;172mA string with the theme's accent color\u{1B}[0m
         \u{1B}[38;5;196mA string with the theme's danger color\u{1B}[0m
-        \u{1B}[38;5;155mA string with the theme's success color\u{1B}[0m
+        \u{1B}[38;5;107mA string with the theme's success color\u{1B}[0m
         """)
     }
 }


### PR DESCRIPTION
I messed up with the extension for `Noora` causing an infinite recursion in the function to render a single choice prompt component. This PR fixes it.