### PR TITLE
feat: make alerts hashable

### DIFF
--- a/Sources/Noora/Noora.swift
+++ b/Sources/Noora/Noora.swift
@@ -1,7 +1,7 @@
 import Foundation
 import Logging
 
-public struct WarningAlert: ExpressibleByStringLiteral, Equatable {
+public struct WarningAlert: ExpressibleByStringLiteral, Equatable, Hashable {
     let message: TerminalText
     let nextStep: TerminalText?
 
@@ -20,7 +20,7 @@ public struct WarningAlert: ExpressibleByStringLiteral, Equatable {
     }
 }
 
-public struct SuccessAlert: ExpressibleByStringLiteral, Equatable {
+public struct SuccessAlert: ExpressibleByStringLiteral, Equatable, Hashable {
     let message: TerminalText
     let nextSteps: [TerminalText]
 

--- a/Sources/Noora/Noora.swift
+++ b/Sources/Noora/Noora.swift
@@ -41,7 +41,7 @@ public struct SuccessAlert: ExpressibleByStringLiteral, Equatable, Hashable {
     }
 }
 
-public struct ErrorAlert: ExpressibleByStringLiteral, Equatable {
+public struct ErrorAlert: ExpressibleByStringLiteral, Equatable, Hashable {
     let message: TerminalText
     let nextSteps: [TerminalText]
 


### PR DESCRIPTION
I'm making alerts hashable so consumers can use it with data structures like `Set` to handle duplicates.