### PR TITLE
feat: make alert properties public

### DIFF
--- a/Sources/Noora/Noora.swift
+++ b/Sources/Noora/Noora.swift
@@ -2,8 +2,8 @@ import Foundation
 import Logging
 
 public struct WarningAlert: ExpressibleByStringLiteral, Equatable, Hashable {
-    let message: TerminalText
-    let nextStep: TerminalText?
+    public let message: TerminalText
+    public let nextStep: TerminalText?
 
     public static func alert(_ message: TerminalText, nextStep: TerminalText? = nil) -> WarningAlert {
         WarningAlert(message, nextStep: nextStep)
@@ -21,8 +21,8 @@ public struct WarningAlert: ExpressibleByStringLiteral, Equatable, Hashable {
 }
 
 public struct SuccessAlert: ExpressibleByStringLiteral, Equatable, Hashable {
-    let message: TerminalText
-    let nextSteps: [TerminalText]
+    public let message: TerminalText
+    public let nextSteps: [TerminalText]
 
     public static func alert(_ message: TerminalText, nextSteps: [TerminalText] = [])
         -> SuccessAlert
@@ -42,8 +42,8 @@ public struct SuccessAlert: ExpressibleByStringLiteral, Equatable, Hashable {
 }
 
 public struct ErrorAlert: ExpressibleByStringLiteral, Equatable, Hashable {
-    let message: TerminalText
-    let nextSteps: [TerminalText]
+    public let message: TerminalText
+    public let nextSteps: [TerminalText]
 
     public static func alert(_ message: TerminalText, nextSteps: [TerminalText] = []) -> ErrorAlert {
         ErrorAlert(message, nextSteps: nextSteps)


### PR DESCRIPTION
I came across a use case where I have to modify an alert collected during the lifecycle of a CLI to include additional next steps. Because the properties of alerts are private, I can't access them to create a new copy of the alert with modified values, so I'm making the properties of alerts public.