### PR TITLE
fix: handle multi-line texts in alerts

### DIFF
--- a/Sources/Noora/Components/Alert.swift
+++ b/Sources/Noora/Components/Alert.swift
@@ -40,7 +40,7 @@ struct Alert {
 
         switch item {
         case let .error(message, nextSteps), let .success(message, nextSteps: nextSteps):
-            message.formatted(theme: theme, terminal: terminal).split(separator: "\n").forEach { messageLine in
+            for messageLine in message.formatted(theme: theme, terminal: terminal).split(separator: "\n") {
                 standardPipeline.write(content: "\(leftBar) \(messageLine) \n")
             }
             var logMessage = """
@@ -55,7 +55,9 @@ struct Alert {
                 \(nextSteps.map { "    - \($0)" }.joined(separator: "\n"))
                 """
                 for nextItem in nextSteps {
-                    nextItem.formatted(theme: theme, terminal: terminal).split(separator: "\n").enumerated().forEach { (nextItemIndex, nextItemLine) in
+                    for (nextItemIndex, nextItemLine) in nextItem.formatted(theme: theme, terminal: terminal)
+                        .split(separator: "\n").enumerated()
+                    {
                         if nextItemIndex == 0 {
                             standardPipeline.write(content: "\(leftBar)  ▸ \(nextItemLine)\n")
                         } else {

--- a/Sources/Noora/Components/Alert.swift
+++ b/Sources/Noora/Components/Alert.swift
@@ -40,7 +40,9 @@ struct Alert {
 
         switch item {
         case let .error(message, nextSteps), let .success(message, nextSteps: nextSteps):
-            standardPipeline.write(content: "\(leftBar) \(message.formatted(theme: theme, terminal: terminal)) \n")
+            message.formatted(theme: theme, terminal: terminal).split(separator: "\n").forEach { messageLine in
+                standardPipeline.write(content: "\(leftBar) \(messageLine) \n")
+            }
             var logMessage = """
             \(item.isSuccess ? "Success" : "Error") alert: \(title)
               - Message: \(message)
@@ -53,7 +55,13 @@ struct Alert {
                 \(nextSteps.map { "    - \($0)" }.joined(separator: "\n"))
                 """
                 for nextItem in nextSteps {
-                    standardPipeline.write(content: "\(leftBar)  ▸ \(nextItem.formatted(theme: theme, terminal: terminal))\n")
+                    nextItem.formatted(theme: theme, terminal: terminal).split(separator: "\n").enumerated().forEach { (nextItemIndex, nextItemLine) in
+                        if nextItemIndex == 0 {
+                            standardPipeline.write(content: "\(leftBar)  ▸ \(nextItemLine)\n")
+                        } else {
+                            standardPipeline.write(content: "\(leftBar)    \(nextItemLine)\n")
+                        }
+                    }
                 }
             }
             logger?.debug("\(logMessage)")


### PR DESCRIPTION
Alerts don't handle multi-line texts gracefully. Note how in the screenshot below how the left bars are missing for the lines of the error. This PR fixes it for the alert message/title and the next steps.

![image](https://github.com/user-attachments/assets/34c8f666-80c4-4686-957d-547890a5b02d)
