### PR TITLE
fix: improve the copy of the warning alert

### DIFF
--- a/Sources/Noora/Components/Alert.swift
+++ b/Sources/Noora/Components/Alert.swift
@@ -30,7 +30,7 @@ struct Alert {
 
         let (title, color, recommendedTitle) = switch item {
         case .error: ("▌ ✖ Error ", theme.danger, "Sorry this didn’t work. Here’s what to try next")
-        case .warning: ("▌ ! Warning ", theme.accent, "Recommended action")
+        case .warning: ("▌ ! Warning ", theme.accent, "The following items may need attention")
         case .success: ("▌ ✔ Success ", theme.success, "Recommended next steps")
         }
 
@@ -74,6 +74,7 @@ struct Alert {
               - Messages:
             \(messages.map { "    - \($0)" }.joined(separator: "\n"))
             """)
+
             for (message, next) in messages {
                 standardPipeline.write(content: "\(leftBar)  ▸ \(message.formatted(theme: theme, terminal: terminal))\n")
                 if let next {

--- a/Tests/NooraTests/Components/CompletionTests.swift
+++ b/Tests/NooraTests/Components/CompletionTests.swift
@@ -24,7 +24,7 @@ struct CompletionTests {
         #expect(standardOutputPipeline.writtenContent.contains("""
         ▌ ! Warning 
         ▌
-        ▌ Recommended action: 
+        ▌ The following items may need attention: 
         ▌  ▸ Your token is about to expire
         ▌   ↳ Run 'tuist projects token create' to generate a new token.
         """.trimmingCharacters(in: .newlines)))


### PR DESCRIPTION
As @fortmarek noted [here](https://github.com/tuist/tuist/pull/7399#discussion_r1993029874), the copy of the warning alert is wrong. It should introduce the reader to the warnings.