### PR TITLE
feat: add support for resetting NooraMock's data

### DIFF
--- a/Sources/Noora/NooraMock.swift
+++ b/Sources/Noora/NooraMock.swift
@@ -52,6 +52,11 @@
             ))
         }
 
+        /// Deletes all the recorded output.
+        public func reset() {
+            standardPipelineEventsRecorder.reset()
+        }
+
         public func singleChoicePrompt<T>(
             title: TerminalText?,
             question: TerminalText,
@@ -176,6 +181,9 @@
 
         private class StandardPipelineEventsRecorder {
             var events: [StandardOutputEvent] = []
+            func reset() {
+                events.removeAll()
+            }
         }
 
         private struct StandardOutputEvent: Equatable {


### PR DESCRIPTION
I noticed on the `tuist/tuist` side of things that we were not resetting the recorded data, leading to the recorded output accumulating, and our test assertions being inaccurate. This PR exposes an API to reset the mock's data.