### PR TITLE
feat: return task value from progressStep

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -23,8 +23,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-log",
       "state" : {
-        "revision" : "96a2f8a0fa41e9e09af4585e2724c4e825410b91",
-        "version" : "1.6.2"
+        "revision" : "3d8596ed08bd13520157f0355e35caed215ffbfa",
+        "version" : "1.6.3"
       }
     }
   ],

--- a/Sources/Noora/Components/CollapsibleStep.swift
+++ b/Sources/Noora/Components/CollapsibleStep.swift
@@ -92,7 +92,7 @@ struct CollapsibleStep {
 
     private func renderInteractiveSuccess() {
         renderer.render(
-            ProgressStep.completionMessage(formattedSuccessMessage(color: theme.primary), theme: theme, terminal: terminal),
+            .progressCompletionMessage(formattedSuccessMessage(color: theme.primary), theme: theme, terminal: terminal),
             standardPipeline: standardPipelines.output
         )
     }
@@ -109,7 +109,7 @@ struct CollapsibleStep {
 
     private func renderInteractiveError() {
         renderer.render(
-            ProgressStep.errorMessage(formattedErrorMessage(color: theme.primary), theme: theme, terminal: terminal),
+            .progressErrorMessage(formattedErrorMessage(color: theme.primary), theme: theme, terminal: terminal),
             standardPipeline: standardPipelines.error
         )
     }

--- a/Sources/Noora/Components/SingleChoicePrompt.swift
+++ b/Sources/Noora/Components/SingleChoicePrompt.swift
@@ -140,7 +140,7 @@ struct SingleChoicePrompt {
         }
         content += " \(selectedOption.1)"
         renderer.render(
-            ProgressStep.completionMessage(content, theme: theme, terminal: terminal),
+            .progressCompletionMessage(content, theme: theme, terminal: terminal),
             standardPipeline: standardPipelines.output
         )
     }

--- a/Sources/Noora/Components/TextPrompt.swift
+++ b/Sources/Noora/Components/TextPrompt.swift
@@ -76,7 +76,7 @@ struct TextPrompt {
         }
         content += " \(input)"
         renderer.render(
-            ProgressStep.completionMessage(content, theme: theme, terminal: terminal),
+            .progressCompletionMessage(content, theme: theme, terminal: terminal),
             standardPipeline: standardPipelines.output
         )
     }

--- a/Sources/Noora/Components/YesOrNoChoicePrompt.swift
+++ b/Sources/Noora/Components/YesOrNoChoicePrompt.swift
@@ -74,7 +74,7 @@ struct YesOrNoChoicePrompt {
         content += " \(answer ? "Yes" : "No")"
 
         renderer.render(
-            ProgressStep.completionMessage(content, theme: theme, terminal: terminal),
+            .progressCompletionMessage(content, theme: theme, terminal: terminal),
             standardPipeline: standardPipelines.output
         )
     }

--- a/Sources/Noora/Noora.swift
+++ b/Sources/Noora/Noora.swift
@@ -168,14 +168,14 @@ public protocol Noorable {
     ///   - renderer: A rendering interface that holds the UI state.
     ///   - task: The asynchronous task to run. The caller can use the argument that the function takes to update the step
     /// message.
-    func progressStep(
+    func progressStep<V>(
         message: String,
         successMessage: String?,
         errorMessage: String?,
         showSpinner: Bool,
         renderer: Rendering,
-        task: @escaping ((String) -> Void) async throws -> Void
-    ) async throws
+        task: @escaping ((String) -> Void) async throws -> V
+    ) async throws -> V
 
     /// A component to represent long-running operations showing the last lines of the sub-process,
     /// and collapsing it on completion.
@@ -353,14 +353,14 @@ public class Noora: Noorable {
         ).run()
     }
 
-    public func progressStep(
+    public func progressStep<V>(
         message: String,
         successMessage: String?,
         errorMessage: String?,
         showSpinner: Bool,
         renderer: Rendering,
-        task: @escaping ((String) -> Void) async throws -> Void
-    ) async throws {
+        task: @escaping ((String) -> Void) async throws -> V
+    ) async throws -> V {
         let progressStep = ProgressStep(
             message: message,
             successMessage: successMessage,
@@ -373,7 +373,7 @@ public class Noora: Noorable {
             standardPipelines: standardPipelines,
             logger: logger
         )
-        try await progressStep.run()
+        return try await progressStep.run()
     }
 
     public func collapsibleStep(
@@ -480,10 +480,10 @@ extension Noorable {
         )
     }
 
-    public func progressStep(
+    public func progressStep<V>(
         message: String,
-        task: @escaping ((String) -> Void) async throws -> Void
-    ) async throws {
+        task: @escaping ((String) -> Void) async throws -> V
+    ) async throws -> V {
         try await progressStep(
             message: message,
             successMessage: nil,
@@ -494,13 +494,13 @@ extension Noorable {
         )
     }
 
-    public func progressStep(
+    public func progressStep<V>(
         message: String,
         successMessage: String?,
         errorMessage: String?,
         showSpinner: Bool,
-        task: @escaping ((String) -> Void) async throws -> Void
-    ) async throws {
+        task: @escaping ((String) -> Void) async throws -> V
+    ) async throws -> V {
         try await progressStep(
             message: message,
             successMessage: successMessage,

--- a/Sources/Noora/NooraMock.swift
+++ b/Sources/Noora/NooraMock.swift
@@ -135,18 +135,18 @@
             noora.warning(alerts)
         }
 
-        public func progressStep(message: String, task: @escaping ((String) -> Void) async throws -> Void) async throws {
+        public func progressStep<V>(message: String, task: @escaping ((String) -> Void) async throws -> V) async throws -> V {
             try await noora.progressStep(message: message, task: task)
         }
 
-        public func progressStep(
+        public func progressStep<V>(
             message: String,
             successMessage: String?,
             errorMessage: String?,
             showSpinner: Bool,
             renderer: Rendering,
-            task: @escaping ((String) -> Void) async throws -> Void
-        ) async throws {
+            task: @escaping ((String) -> Void) async throws -> V
+        ) async throws -> V {
             try await noora.progressStep(
                 message: message,
                 successMessage: successMessage,

--- a/Tests/NooraTests/Components/ProgressStepTests.swift
+++ b/Tests/NooraTests/Components/ProgressStepTests.swift
@@ -10,6 +10,35 @@ struct ProgressStepTests {
     let renderer = MockRenderer()
     let spinner = MockSpinner()
 
+    @Test func returns_task_value() async throws {
+        // Given
+        let standardOutput = MockStandardPipeline()
+        let standardError = MockStandardPipeline()
+        let standardPipelines = StandardPipelines(output: standardOutput, error: standardError)
+
+        let subject = ProgressStep(
+            message: "Loading project graph",
+            successMessage: nil,
+            errorMessage: nil,
+            showSpinner: true,
+            task: { _ in
+                "value"
+            },
+            theme: Theme.test(),
+            terminal: MockTerminal(isInteractive: true),
+            renderer: renderer,
+            standardPipelines: standardPipelines,
+            spinner: spinner,
+            logger: nil
+        )
+
+        // When
+        let value = try await subject.run()
+
+        // Then
+        #expect(value == "value")
+    }
+
     @Test func renders_the_right_output_when_success_and_non_interactive_terminal() async throws {
         // Given
         let standardOutput = MockStandardPipeline()

--- a/docs/content/components/step/progress.md
+++ b/docs/content/components/step/progress.md
@@ -27,7 +27,7 @@ This component represents a step in the execution of a command showing the time 
 ### Example
 
 ```swift
-try await Noora().progressStep(
+let graph = try await Noora().progressStep(
     message: "Processing the graph",
     successMessage: "Project graph processed",
     errorMessage: "Failed to process the project graph"
@@ -40,6 +40,8 @@ try await Noora().progressStep(
 
     // Another asynchronous task.
     try await analyzeGraph(graph)
+
+    return graph
 }
 ```
 


### PR DESCRIPTION
I'm updating `progressStep` to return the `task` value, so we can write:
```swift
        let preview = try await ServiceContext.current!.ui!.progressStep(
            message: "Uploading \(displayName)",
            successMessage: "\(displayName) uploaded",
            errorMessage: "Failed to load manifests",
            showSpinner: true
        ) { _ in
            try await previewsUploadService.uploadPreviews(
                previewUploadType,
                displayName: displayName,
                version: version,
                bundleIdentifier: bundleIdentifier,
                icon: icon,
                supportedPlatforms: supportedPlatforms,
                fullHandle: fullHandle,
                serverURL: serverURL
            )
        }
```

Instead of how we'd need to write as of now:
```swift
        var preview: Preview!
        try await ServiceContext.current!.ui!.progressStep(
            message: "Uploading \(displayName)",
            successMessage: "\(displayName) uploaded",
            errorMessage: "Failed to load manifests",
            showSpinner: true
        ) { _ in
            preview = try await previewsUploadService.uploadPreviews(
                previewUploadType,
                displayName: displayName,
                version: version,
                bundleIdentifier: bundleIdentifier,
                icon: icon,
                supportedPlatforms: supportedPlatforms,
                fullHandle: fullHandle,
                serverURL: serverURL
            )
        }
```