### PR TITLE
fix: formatting of links in non interactive terminals

### DIFF
--- a/Sources/Noora/Utilities/TerminalText.swift
+++ b/Sources/Noora/Utilities/TerminalText.swift
@@ -56,7 +56,12 @@ public struct TerminalText: Equatable, Hashable {
             case let .link(
                 title,
                 href
-            ): "\u{1B}]8;;\(href)\u{1B}\\\(title.hexIfColoredTerminal(theme.secondary, terminal))\u{1B}]8;;\u{1B}\\"
+            ): 
+                if terminal.isInteractive {
+                    "\u{1B}]8;;\(href)\u{1B}\\\(title.hexIfColoredTerminal(theme.secondary, terminal))\u{1B}]8;;\u{1B}\\"
+                } else {
+                    "<\(title): \(href)>"
+                }
             case let .primary(primary): primary.hexIfColoredTerminal(theme.primary, terminal)
             case let .secondary(secondary): secondary.hexIfColoredTerminal(theme.secondary, terminal)
             case let .muted(muted): muted.hexIfColoredTerminal(theme.muted, terminal)

--- a/Tests/NooraTests/Utilities/TerminalTextTests.swift
+++ b/Tests/NooraTests/Utilities/TerminalTextTests.swift
@@ -15,6 +15,17 @@ struct TerminalTextTests {
         // Then
         #expect(got == "Please run 'tuist project tokens create' to obtain a new token.")
     }
+    
+    @Test func linksAreNotFormattedWhenNonInteractiveTerminal() {
+        // Given
+        let subject: TerminalText = "Visit \(.link(title: "Tuist", href: "https://tuist.dev"))"
+        
+        // When
+        let got = subject.formatted(theme: .default, terminal: Terminal(isInteractive: false, isColored: true))
+
+        // Then
+        #expect(got == "Visit <Tuist: https://tuist.dev>")
+    }
 
     @Test func terminalTextIsFormattedWithTheme() {
         // Force Rainbow to apply colors to the output


### PR DESCRIPTION
I noticed links are formatted using ANSI escape characters in non-interactive terminals, resulting in the output being ugly with all the escape characters.

This PR fixes it by taking the interactivity into account and formatting accordingly.