### PR TITLE
feat: support path components in TerminalText

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,6 +1,15 @@
 {
   "pins" : [
     {
+      "identity" : "path",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/tuist/path",
+      "state" : {
+        "revision" : "7c74ac435e03a927c3a73134c48b61e60221abcb",
+        "version" : "0.3.8"
+      }
+    },
+    {
       "identity" : "rainbow",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/onevcat/Rainbow",

--- a/Package.swift
+++ b/Package.swift
@@ -23,6 +23,7 @@ let package = Package(
             url: "https://github.com/apple/swift-argument-parser", .upToNextMajor(from: "1.5.0")
         ),
         .package(url: "https://github.com/apple/swift-log", .upToNextMajor(from: "1.6.3")),
+        .package(url: "https://github.com/tuist/path", .upToNextMinor(from: "0.3.8")),
     ],
     targets: [
         .executableTarget(
@@ -36,6 +37,7 @@ let package = Package(
             dependencies: [
                 "Rainbow",
                 .product(name: "Logging", package: "swift-log"),
+                .product(name: "Path", package: "path"),
             ],
             swiftSettings: [
                 .define("MOCKING", .when(configuration: .debug)),


### PR DESCRIPTION
I'm adding support for a new type of component in `TerminalText`, paths:

```swift
let message: TerminalText = "Project generated at \(.path(directory))"
```

Noora will automatically format the path to be relative to the working directory to be shorter than showing the entire absolute path.