### PR TITLE
Add commit parsers and update renovate config

### DIFF
--- a/cliff.toml
+++ b/cliff.toml
@@ -87,6 +87,22 @@ commit_preprocessors = [
     # remove issue numbers from commits
     { pattern = '\((\w+\s)?#([0-9]+)\)', replace = "" },
 ]
+commit_parsers = [
+    { message = "^feat", group = "Features" },
+    { message = "^fix", group = "Bug Fixes" },
+    { message = "^doc", group = "Documentation" },
+    { message = "^perf", group = "Performance" },
+    { message = "^refactor", group = "Refactor" },
+    { message = "^style", group = "Styling" },
+    { message = "^test", group = "Testing" },
+    { message = "^chore\\(spm.*\\)", skip = false },
+    { message = "^chore\\(deps.*\\)", skip = true },
+    { message = "^chore\\(pr\\)", skip = true },
+    { message = "^chore\\(pull\\)", skip = true },
+    { message = "^chore\\(release\\): prepare for", skip = true },
+    { message = "^chore|^ci", group = "Miscellaneous Tasks" },
+    { body = ".*security", group = "Security" },
+]
 # protect breaking changes from being skipped due to matching a skipping commit_parser
 protect_breaking_commits = false
 # filter out the commits that are not matched by commit parsers

--- a/renovate.json
+++ b/renovate.json
@@ -10,7 +10,12 @@
       "matchUpdateTypes": ["minor", "patch", "pin", "digest"],
       "automerge": true,
       "automergeType": "pr",
-      "automergeStrategy": "auto"
+      "automergeStrategy": "auto",
+      "semanticCommitScope": "deps"
+    },
+    {
+      "matchManagers": ["swift"],
+      "semanticCommitScope": "spm"
     }
   ],
   "lockFileMaintenance": {


### PR DESCRIPTION
We are doing releases when Renovate updates dependencies that are non-SPM. We should not do that because those changes have no impact in Noora itself.

This PR adjusts the Renovate configuration to apply a different convention for SPM dependency update PRs, and configures Git cliff to skip other Renovatebot PRs.