### PR TITLE
fix: align with the ANSI color standard

### DIFF
--- a/Sources/Noora/Utilities/Terminal.swift
+++ b/Sources/Noora/Utilities/Terminal.swift
@@ -142,8 +142,11 @@ public struct Terminal: Terminaling {
     public static func isColored() -> Bool {
         if ProcessInfo.processInfo.environment["NO_COLOR"] != nil {
             return false
-        } else {
+        } else if ProcessInfo.processInfo.environment["CLICOLOR_FORCE"] != nil {
             return true
+        } else {
+            let isPiped = isatty(fileno(stdout)) == 0
+            return !isPiped
         }
     }
 }


### PR DESCRIPTION
Resolves: https://github.com/tuist/tuist/issues/7513

We should respect the ANSI color environment variables as documented [here](https://bixense.com/clicolors/):
```python
import os, sys

def has_colors():
    if os.environ.get('NO_COLOR'):
        return False
    elif os.environ.get('CLICOLOR_FORCE'):
        return True
    return sys.stdout.isatty()
```