### PR TITLE
fix: indentation issue in non-interactive output

### DIFF
--- a/Sources/Noora/Components/ProgressBarStep.swift
+++ b/Sources/Noora/Components/ProgressBarStep.swift
@@ -114,7 +114,7 @@ struct ProgressBarStep<V> {
                 theme: theme,
                 terminal: terminal
             )
-            standardPipelines.output.write(content: "   \(message)\n")
+            standardPipelines.output.write(content: "\(message)\n")
             logger?.debug("'\(message)' succeeded with '\(successMessage ?? message)'")
             return result
         } catch {


### PR DESCRIPTION
The progress bar step component had a bug in its non-interactive version that [caused](https://github.com/tuist/tuist/pull/7533#discussion_r2060507574) success messages to have an extra indentation.