### PR TITLE
fix: Prevent divide-by-zero when terminal reports zero columns or rows

### DIFF
--- a/Sources/Noora/Utilities/Terminal.swift
+++ b/Sources/Noora/Utilities/Terminal.swift
@@ -97,7 +97,12 @@ public struct Terminal: Terminaling {
     public func size() -> TerminalSize? {
         var w = winsize()
         if ioctl(STDOUT_FILENO, UInt(TIOCGWINSZ), &w) == 0 {
-            return TerminalSize(rows: Int(w.ws_row), columns: Int(w.ws_col))
+            let rows = Int(w.ws_row)
+            let cols = Int(w.ws_col)
+            guard rows > 0, cols > 0 else {
+                return nil
+            }
+            return TerminalSize(rows: rows, columns: cols)
         } else {
             return nil
         }


### PR DESCRIPTION


This PR adds a simple guard to Terminal.size() to ensure it only returns a valid TerminalSize when both ws_col and ws_row are greater than zero.

![CleanShot 2025-05-03 at 04 14 47@2x](https://github.com/user-attachments/assets/fd3ff2ec-b698-476d-a0d9-a80f82b0a58b)
