### PR TITLE
Add field to Filters and :percentage type

### DIFF
--- a/web/lib/noora/filter.ex
+++ b/web/lib/noora/filter.ex
@@ -1,160 +1,20 @@
-defmodule Noora.Filter do
-  @moduledoc """
-  A comprehensive filtering system with dropdown and active filter components.
-
-  ## Overview
-
-  The filter system consists of two main components:
-  - `filter_dropdown/1` - A dropdown to add new filters
-  - `active_filter/1` - Displays and manages active filters
-
-  ## Filter Configuration
-
-  Filters are defined using the `Noora.Filter.Filter` struct with the following fields:
-
-  - `:id` - Unique identifier for the filter (e.g., "status", "created_at")
-  - `:display_name` - Human-readable name shown in the UI
-  - `:type` - Filter type (`:text`, `:number`, or `:option`)
-  - `:options` - List of available options (for `:option` type only)
-  - `:options_display_names` - Map of option values to display names
-  - `:operator` - Comparison operator (e.g., `:==`, `:=~`, `:<`)
-  - `:value` - Current filter value
-
-  ### Filter Types and Operators
-
-  - **Text filters** (`:text`) - Support operators: `:==` (is), `:=~` (contains)
-  - **Number filters** (`:number`) - Support operators: `:==`, `:<`, `:>`, `:<=`, `:>=`
-  - **Option filters** (`:option`) - Support operators: `:==` (is), `:!=` (is not)
-
-  ## LiveView Setup
-
-  ### 1. Define Available Filters
-
-  ```elixir
-  @impl true
-  def mount(_params, _session, socket) do
-    available_filters = [
-      %Noora.Filter.Filter{
-        id: "status",
-        display_name: "Status",
-        type: :option,
-        options: [:active, :inactive, :pending],
-        options_display_names: %{
-          active: "Active",
-          inactive: "Inactive",
-          pending: "Pending"
-        }
-      },
-      %Noora.Filter.Filter{
-        id: "name",
-        display_name: "Name",
-        type: :text
-      },
-      %Noora.Filter.Filter{
-        id: "amount",
-        display_name: "Amount",
-        type: :number
-      }
-    ]
-
-    {:ok, assign(socket, available_filters: available_filters, active_filters: [])}
-  end
-  ```
-
-  ### 2. Handle Filter Events
-
-  ```elixir
-  @impl true
-  def handle_event("add_filter", %{"value" => filter_id}, socket) do
-    # Add the selected filter with the Operations helper
-    params = Noora.Filter.Operations.add_filter_to_query(filter_id, socket)
-    {:noreply, push_patch(socket, to: ~p"/items?\#{params}")}
-  end
-
-  @impl true
-  def handle_event("update_filter", params, socket) do
-    # Update filter value or operator
-    updated_params = Noora.Filter.Operations.update_filters_in_query(params, socket)
-    {:noreply, push_patch(socket, to: ~p"/items?\#{updated_params}")}
-  end
-  ```
-
-  ### 3. Parse Filters from URL
-
-  ```elixir
-  @impl true
-  def handle_params(params, _uri, socket) do
-    active_filters = Noora.Filter.Operations.decode_filters_from_query(
-      params,
-      socket.assigns.available_filters
-    )
-    
-    {:noreply, assign(socket, active_filters: active_filters)}
-  end
-  ```
-
-  ### 4. Render the Components
-
-  ```heex
-  <div class="flex gap-2">
-    <.filter_dropdown
-      id="add-filter"
-      available_filters={@available_filters}
-      active_filters={@active_filters}
-      on_select="add_filter"
-    />
-    
-    <.active_filter :for={filter <- @active_filters} filter={filter} />
-  </div>
-  ```
-
-  ## Integration with Flop
-
-  The filter system integrates seamlessly with Flop for query building:
-
-  ```elixir
-  def list_items(params, available_filters) do
-    active_filters = Noora.Filter.Operations.decode_filters_from_query(params, available_filters)
-    flop_filters = Noora.Filter.Operations.convert_filters_to_flop(active_filters)
-    
-    Flop.validate_and_run(Item, %{filters: flop_filters}, for: Item)
-  end
-  ```
-
-  ## URL Parameter Format
-
-  Filters are stored in URL parameters using the pattern:
-  - `filter_{id}_op` - The operator (e.g., "==", "=~")
-  - `filter_{id}_val` - The value
-
-  Example: `?filter_status_op===&filter_status_val=active&filter_amount_op=>&filter_amount_val=100`
-  """
+defmodule TuistWeb.Noora.Filter do
+  @moduledoc false
 
   use Phoenix.Component
 
-  import Noora.Button
-  import Noora.Dropdown
-  import Noora.Icon
-  import Noora.TextInput
+  import TuistWeb.Noora.Button
+  import TuistWeb.Noora.Dropdown
+  import TuistWeb.Noora.Icon
+  import TuistWeb.Noora.TextInput
 
   alias Phoenix.LiveView.JS
 
   defmodule Filter do
-    @moduledoc """
-    Represents a filter configuration with its current state.
-
-    ## Fields
-
-    - `:id` - Unique identifier for the filter
-    - `:display_name` - Human-readable name shown in the UI
-    - `:type` - Filter type (`:text`, `:number`, or `:option`)
-    - `:options` - List of available options (for `:option` type only)
-    - `:options_display_names` - Map of option values to display names
-    - `:operator` - Comparison operator (e.g., `:==`, `:=~`, `:<`)
-    - `:value` - Current filter value
-    """
+    @moduledoc false
     defstruct [
       :id,
+      :field,
       :display_name,
       :type,
       :options,
@@ -166,7 +26,7 @@ defmodule Noora.Filter do
 
   defmodule Operations do
     @moduledoc false
-    alias Noora.Filter.Filter
+    alias TuistWeb.Noora.Filter.Filter
 
     def update_filters(current_filters, :change_value, params) do
       filter_id = params["payload_filter_id"]
@@ -244,7 +104,12 @@ defmodule Noora.Filter do
     def to_flop_filter(%Filter{value: nil}), do: []
     def to_flop_filter(%Filter{value: ""}), do: []
 
-    def to_flop_filter(%Filter{id: id, operator: operator, value: value, options_display_names: display_names})
+    def to_flop_filter(%Filter{
+          id: id,
+          operator: operator,
+          value: value,
+          options_display_names: display_names
+        })
         when is_map(display_names) and not is_nil(value) do
       option_key =
         display_names
@@ -257,8 +122,8 @@ defmodule Noora.Filter do
       [%{field: String.to_existing_atom(id), op: operator, value: option_key}]
     end
 
-    def to_flop_filter(%Filter{id: id, operator: operator, value: value}) do
-      [%{field: String.to_existing_atom(id), op: operator, value: value}]
+    def to_flop_filter(%Filter{field: field, operator: operator, value: value}) do
+      [%{field: field, op: operator, value: value}]
     end
 
     def convert_filters_to_flop(filters) when is_list(filters) do
@@ -276,7 +141,8 @@ defmodule Noora.Filter do
       end)
     end
 
-    def decode_filters_from_query(params, available_filters) when is_map(params) and is_list(available_filters) do
+    def decode_filters_from_query(params, available_filters)
+        when is_map(params) and is_list(available_filters) do
       params
       |> extract_filter_ids()
       |> Enum.flat_map(&build_filter(&1, params, available_filters))
@@ -326,7 +192,7 @@ defmodule Noora.Filter do
       end
     end
 
-    defp process_option_value(val, %{type: :number}) do
+    defp process_option_value(val, %{type: :percentage}) do
       case Float.parse(val) do
         {float_val, ""} -> float_val
         _ -> val
@@ -485,10 +351,33 @@ defmodule Noora.Filter do
               <.text_input
                 name="value"
                 type="basic"
-                input_type={@filter.type == :number && "number"}
-                min={@filter.type == :number && 0}
-                max={@filter.type == :number && 100}
-                step={@filter.type == :number && 0.1}
+                input_type={
+                  case @filter.type do
+                    :number -> "number"
+                    :percentage -> "number"
+                    _ -> nil
+                  end
+                }
+                min={
+                  case @filter.type do
+                    :number -> 0
+                    :percentage -> 0
+                    _ -> nil
+                  end
+                }
+                max={
+                  case @filter.type do
+                    :percentage -> 100
+                    _ -> nil
+                  end
+                }
+                step={
+                  case @filter.type do
+                    :number -> 1
+                    :percentage -> 0.1
+                    _ -> nil
+                  end
+                }
                 value={@filter.value}
                 phx-hook="PlaceCursorAtEnd"
               />
@@ -524,6 +413,7 @@ defmodule Noora.Filter do
   defp operators(:option), do: [:==, :!=]
   defp operators(:text), do: [:==, :=~]
   defp operators(:number), do: [:==, :<, :>, :<=, :>=]
+  defp operators(:percentage), do: [:==, :<, :>, :<=, :>=]
 
   def operator_text(:==), do: "is"
   def operator_text(:!=), do: "is not"
@@ -534,7 +424,11 @@ defmodule Noora.Filter do
   def operator_text(:>=), do: "greater than or equal to"
   def operator_text(operator), do: to_string(operator)
 
-  defp get_display_value(%Filter{type: :option, value: value, options_display_names: display_names})
+  defp get_display_value(%Filter{
+         type: :option,
+         value: value,
+         options_display_names: display_names
+       })
        when is_map(display_names) and not is_nil(value) do
     # Value could be an atom, integer, or string
     Map.get(display_names, value, value)


### PR DESCRIPTION
Doing two things here:
- Adding a field to `Filters` to make the field more explicit. If you have multiple filters in a same page, it's also useful to have IDs detached from the actual field, so they don't override each other.
- The `:number` filter type was very much tailored to percentage, such as by constraining the max value. I'm adding a `:percentage` type and keeping `:number` for more generic number values.