### PR TITLE
fix: releases by adding Package.swift and Package.resolved to observed paths

### DIFF
--- a/.github/workflows/release-cli.yml
+++ b/.github/workflows/release-cli.yml
@@ -5,7 +5,7 @@ on:
     branches:
       - main
     paths:
-      - "cli/**"
+      - "cli/** Package.swift Package.resolved"
       - ".github/workflows/release-cli.yml"
   workflow_dispatch:
     inputs:
@@ -56,14 +56,14 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          NEXT_VERSION=$(git cliff --config cli/cliff.toml --include-path cli/** --bumped-version)
+          NEXT_VERSION=$(git cliff --config cli/cliff.toml --include-path cli/** Package.swift Package.resolved --bumped-version)
           echo "NEXT_VERSION=$NEXT_VERSION" >> "$GITHUB_OUTPUT"
           echo "Next CLI version will be: $NEXT_VERSION"
       - name: Update CHANGELOG.md
         if: steps.check-changes.outputs.has-changes == 'true'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: git cliff --config cli/cliff.toml --include-path cli/** --bump -o cli/CHANGELOG.md
+        run: git cliff --config cli/cliff.toml --include-path cli/** Package.swift Package.resolved --bump -o cli/CHANGELOG.md
       - name: Get release notes
         id: release-notes
         if: steps.check-changes.outputs.has-changes == 'true'
@@ -71,7 +71,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           echo "RELEASE_NOTES<<EOF" >> "$GITHUB_OUTPUT"
-          git cliff --config cli/cliff.toml --include-path cli/** --latest >> "$GITHUB_OUTPUT"
+          git cliff --config cli/cliff.toml --include-path cli/** Package.swift Package.resolved --latest >> "$GITHUB_OUTPUT"
           echo "EOF" >> "$GITHUB_OUTPUT"
       - name: Commit changes
         id: auto-commit-action
@@ -92,4 +92,3 @@ jobs:
           tag_name: ${{ steps.next-version.outputs.NEXT_VERSION }}
           body: ${{ steps.release-notes.outputs.RELEASE_NOTES }}
           target_commitish: ${{ steps.auto-commit-action.outputs.commit_hash }}
-


### PR DESCRIPTION
The CLI didn't get released as the changes were only to files outside the `cli` repository.