### PR TITLE
feat: allow row_click in table to return nil

### DIFF
--- a/web/lib/noora/table.ex
+++ b/web/lib/noora/table.ex
@@ -102,7 +102,9 @@ defmodule Noora.Table do
           >
             <td
               :for={col <- @col}
-              data-selectable={not is_nil(@row_navigate) or not is_nil(@row_click.(row))}
+              data-selectable={
+                not is_nil(@row_navigate) or (not is_nil(@row_click) and not is_nil(@row_click.(row)))
+              }
             >
               <%= if @row_navigate do %>
                 <.link navigate={@row_navigate.(row)} data-part="link">


### PR DESCRIPTION
We have a need to dynamically allow the row to be not clickable based on the value. This adds support for that by checking if the resolved value is `nil` instead of just whether the `row_click` method is `nil`.