### PR TITLE
fix: ensure button link can't be clicked when disabled

### DIFF
--- a/web/css/breadcrumbs.css
+++ b/web/css/breadcrumbs.css
@@ -61,8 +61,8 @@
     }
 
     &:not(
-        :has([data-part="icon"], [data-part="avatar"], [data-part="selector"])
-      ) {
+      :has([data-part="icon"], [data-part="avatar"], [data-part="selector"])
+    ) {
       padding: var(--noora-spacing-2);
     }
 

--- a/web/lib/noora/button.ex
+++ b/web/lib/noora/button.ex
@@ -39,7 +39,7 @@ defmodule Noora.Button do
 
   def button(assigns) do
     ~H"""
-    <%= if @href || @navigate || @patch do %>
+    <%= if (@href || @navigate || @patch) && !@rest[:disabled] do %>
       <.link
         class="noora-button"
         href={@href}


### PR DESCRIPTION
Related: https://github.com/tuist/tuist/issues/7784

The link of a disabled button can still be clicked even when the cursor is disabled. This PR fixes that by ensuring the `href`, `navigate`, or `patch` are not set when the button is disabled.