### PR TITLE
feat: add `:rest` attribute to checkbox

### DIFF
--- a/web/lib/noora/checkbox.ex
+++ b/web/lib/noora/checkbox.ex
@@ -27,6 +27,8 @@ defmodule Noora.Checkbox do
     doc: "Whether the checkbox is part of a multiple checkbox group."
   )
 
+  attr(:rest, :global, doc: "Additional attributes")
+
   def checkbox(%{field: %FormField{} = field} = assigns) do
     assigns
     |> assign(field: nil, id: assigns.id || field.id)
@@ -48,6 +50,7 @@ defmodule Noora.Checkbox do
       phx-hook="NooraCheckbox"
       data-indeterminate={@indeterminate}
       data-disabled={@disabled}
+      {@rest}
     >
       <label data-part="root">
         <input data-part="hidden-input" />


### PR DESCRIPTION
Want to add `tabindex` to some auth pages - this wasn't able to be passed to the checkbox component up until now.