### PR TITLE
feat: simplify formatHours to always show hours only

### DIFF
--- a/web/js/formatters.js
+++ b/web/js/formatters.js
@@ -1,15 +1,9 @@
 /**
  * Formats hours into a human readable string
  * @param {number} hours - The time duration in hours
- * @returns {string} Formatted time string (e.g., "1h", "2h", "1d 5h")
+ * @returns {string} Formatted time string (e.g., "1h", "25h", "168h")
  */
 export function formatHours(hours) {
-  if (Math.abs(hours) < 24) {
-    const wholeHours = Math.round(hours);
-    return `${wholeHours}h`;
-  } else {
-    const days = Math.floor(hours / 24);
-    const remainingHours = Math.round(hours % 24);
-    return `${days}d ${remainingHours}h`;
-  }
+  const wholeHours = Math.round(hours);
+  return `${wholeHours}h`;
 }

--- a/web/js/formatters.js
+++ b/web/js/formatters.js
@@ -10,10 +10,6 @@ export function formatHours(hours) {
   } else {
     const days = Math.floor(hours / 24);
     const remainingHours = Math.round(hours % 24);
-    if (remainingHours === 0) {
-      return `${days}d`;
-    } else {
-      return `${days}d ${remainingHours}h`;
-    }
+    return `${days}d ${remainingHours}h`;
   }
 }

--- a/web/js/formatters.js
+++ b/web/js/formatters.js
@@ -1,23 +1,15 @@
 /**
  * Formats hours into a human readable string
  * @param {number} hours - The time duration in hours
- * @returns {string} Formatted time string (e.g., "30m", "2h 30m", "1d 5h")
+ * @returns {string} Formatted time string (e.g., "1h", "2h", "1d 5h")
  */
 export function formatHours(hours) {
-  if (hours < 1) {
-    const minutes = Math.round(hours * 60);
-    return `${minutes}m`;
-  } else if (hours < 24) {
-    const wholeHours = Math.floor(hours);
-    const minutes = Math.round((hours - wholeHours) * 60);
-    if (minutes === 0) {
-      return `${wholeHours}h`;
-    } else {
-      return `${wholeHours}h ${minutes}m`;
-    }
+  if (Math.abs(hours) < 24) {
+    const wholeHours = Math.round(hours);
+    return `${wholeHours}h`;
   } else {
     const days = Math.floor(hours / 24);
-    const remainingHours = Math.floor(hours % 24);
+    const remainingHours = Math.round(hours % 24);
     if (remainingHours === 0) {
       return `${days}d`;
     } else {

--- a/web/js/formatters.test.js
+++ b/web/js/formatters.test.js
@@ -2,51 +2,44 @@ import { describe, it, expect } from "vitest";
 import { formatHours } from "./formatters.js";
 
 describe("formatHours", () => {
-  describe("when hours is less than 1", () => {
-    it("formats fractional hours as minutes", () => {
-      expect(formatHours(0.5)).toBe("30m");
-      expect(formatHours(0.25)).toBe("15m");
-      expect(formatHours(0.75)).toBe("45m");
+  describe("when hours is less than 24", () => {
+    it("formats fractional hours as rounded hours", () => {
+      expect(formatHours(0.5)).toBe("1h");
+      expect(formatHours(0.25)).toBe("0h");
+      expect(formatHours(0.75)).toBe("1h");
     });
 
-    it("rounds to nearest minute", () => {
-      expect(formatHours(0.016667)).toBe("1m"); // 1 minute
-      expect(formatHours(0.033333)).toBe("2m"); // 2 minutes
+    it("rounds to nearest hour", () => {
+      expect(formatHours(0.4)).toBe("0h");
+      expect(formatHours(0.6)).toBe("1h");
     });
 
     it("handles zero hours", () => {
-      expect(formatHours(0)).toBe("0m");
+      expect(formatHours(0)).toBe("0h");
     });
 
     it("handles very small values", () => {
-      expect(formatHours(0.001)).toBe("0m");
-      expect(formatHours(0.008333)).toBe("0m"); // Less than 0.5 minutes
+      expect(formatHours(0.001)).toBe("0h");
+      expect(formatHours(0.4)).toBe("0h");
     });
-  });
 
-  describe("when hours is between 1 and 24", () => {
-    it("formats whole hours without minutes", () => {
+    it("formats whole hours", () => {
       expect(formatHours(1)).toBe("1h");
       expect(formatHours(5)).toBe("5h");
       expect(formatHours(12)).toBe("12h");
       expect(formatHours(23)).toBe("23h");
     });
 
-    it("formats hours with minutes", () => {
-      expect(formatHours(1.5)).toBe("1h 30m");
-      expect(formatHours(2.25)).toBe("2h 15m");
-      expect(formatHours(5.75)).toBe("5h 45m");
-      expect(formatHours(12.1)).toBe("12h 6m");
-    });
-
-    it("rounds minutes to nearest whole number", () => {
-      expect(formatHours(1.0083)).toBe("1h"); // 0.5 minutes rounds to 0
-      expect(formatHours(1.0167)).toBe("1h 1m"); // 1 minute
-      expect(formatHours(2.9917)).toBe("2h 60m"); // 59.5 minutes rounds to 60, shows as 2h 60m
+    it("rounds fractional hours to nearest whole hour", () => {
+      expect(formatHours(1.3)).toBe("1h");
+      expect(formatHours(1.5)).toBe("2h");
+      expect(formatHours(2.7)).toBe("3h");
+      expect(formatHours(12.1)).toBe("12h");
     });
 
     it("handles edge case at 24 hours boundary", () => {
-      expect(formatHours(23.99)).toBe("23h 59m"); // Shows as 23h 59m
+      expect(formatHours(23.4)).toBe("23h");
+      expect(formatHours(23.6)).toBe("24h");
     });
   });
 
@@ -64,9 +57,10 @@ describe("formatHours", () => {
       expect(formatHours(75)).toBe("3d 3h");
     });
 
-    it("ignores minutes when calculating days", () => {
-      expect(formatHours(24.5)).toBe("1d"); // 24.5 hours = 1 day (remaining hours is 0, so not shown)
-      expect(formatHours(25.75)).toBe("1d 1h"); // 25.75 hours = 1 day 1 hour (minutes ignored)
+    it("rounds remaining hours to nearest whole hour", () => {
+      expect(formatHours(24.3)).toBe("1d");
+      expect(formatHours(24.6)).toBe("1d 1h");
+      expect(formatHours(25.7)).toBe("1d 2h");
     });
 
     it("handles large values", () => {
@@ -78,15 +72,13 @@ describe("formatHours", () => {
 
   describe("edge cases", () => {
     it("handles negative values gracefully", () => {
-      // Note: The current implementation doesn't handle negative values explicitly
-      // This test documents current behavior - you may want to add validation
-      expect(formatHours(-1)).toBe("-60m");
-      expect(formatHours(-24)).toBe("-1440m"); // -24 * 60 = -1440 minutes
+      expect(formatHours(-1)).toBe("-1h");
+      expect(formatHours(-24)).toBe("-1d");
     });
 
     it("handles decimal precision edge cases", () => {
-      expect(formatHours(1.9999)).toBe("1h 60m"); // Shows as 1h 60m due to rounding
-      expect(formatHours(0.99999)).toBe("60m"); // Should round to 60m (not 1h)
+      expect(formatHours(1.9999)).toBe("2h");
+      expect(formatHours(0.99999)).toBe("1h");
     });
   });
 });

--- a/web/js/formatters.test.js
+++ b/web/js/formatters.test.js
@@ -2,7 +2,7 @@ import { describe, it, expect } from "vitest";
 import { formatHours } from "./formatters.js";
 
 describe("formatHours", () => {
-  describe("when hours is less than 24", () => {
+  describe("basic formatting", () => {
     it("formats fractional hours as rounded hours", () => {
       expect(formatHours(0.5)).toBe("1h");
       expect(formatHours(0.25)).toBe("0h");
@@ -36,49 +36,41 @@ describe("formatHours", () => {
       expect(formatHours(2.7)).toBe("3h");
       expect(formatHours(12.1)).toBe("12h");
     });
-
-    it("handles edge case at 24 hours boundary", () => {
-      expect(formatHours(23.4)).toBe("23h");
-      expect(formatHours(23.6)).toBe("24h");
-    });
   });
 
-  describe("when hours is 24 or more", () => {
-    it("formats exact days with 0 hours", () => {
-      expect(formatHours(24)).toBe("1d 0h");
-      expect(formatHours(48)).toBe("2d 0h");
-      expect(formatHours(72)).toBe("3d 0h");
+  describe("large values", () => {
+    it("formats hours >= 24 as hours only", () => {
+      expect(formatHours(24)).toBe("24h");
+      expect(formatHours(25)).toBe("25h");
+      expect(formatHours(25.5)).toBe("26h");
+      expect(formatHours(48)).toBe("48h");
+      expect(formatHours(72)).toBe("72h");
     });
 
-    it("formats days with remaining hours", () => {
-      expect(formatHours(25)).toBe("1d 1h");
-      expect(formatHours(30)).toBe("1d 6h");
-      expect(formatHours(49)).toBe("2d 1h");
-      expect(formatHours(75)).toBe("3d 3h");
+    it("rounds fractional hours to nearest whole hour", () => {
+      expect(formatHours(24.3)).toBe("24h");
+      expect(formatHours(24.6)).toBe("25h");
+      expect(formatHours(25.7)).toBe("26h");
     });
 
-    it("rounds remaining hours to nearest whole hour", () => {
-      expect(formatHours(24.3)).toBe("1d 0h");
-      expect(formatHours(24.6)).toBe("1d 1h");
-      expect(formatHours(25.7)).toBe("1d 2h");
-    });
-
-    it("handles large values", () => {
-      expect(formatHours(168)).toBe("7d 0h"); // 1 week
-      expect(formatHours(720)).toBe("30d 0h"); // 30 days
-      expect(formatHours(8760)).toBe("365d 0h"); // 1 year
+    it("handles very large values", () => {
+      expect(formatHours(168)).toBe("168h"); // 1 week
+      expect(formatHours(720)).toBe("720h"); // 30 days
+      expect(formatHours(8760)).toBe("8760h"); // 1 year
     });
   });
 
   describe("edge cases", () => {
     it("handles negative values gracefully", () => {
       expect(formatHours(-1)).toBe("-1h");
-      expect(formatHours(-24)).toBe("-1d 0h");
+      expect(formatHours(-24)).toBe("-24h");
+      expect(formatHours(-25.5)).toBe("-25h");
     });
 
     it("handles decimal precision edge cases", () => {
       expect(formatHours(1.9999)).toBe("2h");
       expect(formatHours(0.99999)).toBe("1h");
+      expect(formatHours(23.9999)).toBe("24h");
     });
   });
 });

--- a/web/js/formatters.test.js
+++ b/web/js/formatters.test.js
@@ -44,10 +44,10 @@ describe("formatHours", () => {
   });
 
   describe("when hours is 24 or more", () => {
-    it("formats exact days without hours", () => {
-      expect(formatHours(24)).toBe("1d");
-      expect(formatHours(48)).toBe("2d");
-      expect(formatHours(72)).toBe("3d");
+    it("formats exact days with 0 hours", () => {
+      expect(formatHours(24)).toBe("1d 0h");
+      expect(formatHours(48)).toBe("2d 0h");
+      expect(formatHours(72)).toBe("3d 0h");
     });
 
     it("formats days with remaining hours", () => {
@@ -58,22 +58,22 @@ describe("formatHours", () => {
     });
 
     it("rounds remaining hours to nearest whole hour", () => {
-      expect(formatHours(24.3)).toBe("1d");
+      expect(formatHours(24.3)).toBe("1d 0h");
       expect(formatHours(24.6)).toBe("1d 1h");
       expect(formatHours(25.7)).toBe("1d 2h");
     });
 
     it("handles large values", () => {
-      expect(formatHours(168)).toBe("7d"); // 1 week
-      expect(formatHours(720)).toBe("30d"); // 30 days
-      expect(formatHours(8760)).toBe("365d"); // 1 year
+      expect(formatHours(168)).toBe("7d 0h"); // 1 week
+      expect(formatHours(720)).toBe("30d 0h"); // 30 days
+      expect(formatHours(8760)).toBe("365d 0h"); // 1 year
     });
   });
 
   describe("edge cases", () => {
     it("handles negative values gracefully", () => {
       expect(formatHours(-1)).toBe("-1h");
-      expect(formatHours(-24)).toBe("-1d");
+      expect(formatHours(-24)).toBe("-1d 0h");
     });
 
     it("handles decimal precision edge cases", () => {


### PR DESCRIPTION
Needed for https://github.com/tuist/tuist/pull/7807#issuecomment-3062647556

## Summary
Simplifies the `formatHours` function to always display time as hours only, removing the day/hour breakdown for a cleaner, more consistent format.

## Changes
- Always formats as "Xh" regardless of duration (e.g., "1h", "25h", "168h")
- Rounds fractional hours to nearest whole hour using `Math.round()`
- Simplified implementation with consistent behavior across all time ranges
- Removed complex day/hour calculations for better readability
- Updated all tests to match hours-only format

## Examples
- `formatHours(1.5)` → `"2h"`
- `formatHours(25.5)` → `"26h"` 
- `formatHours(168)` → `"168h"` (1 week)
- `formatHours(720)` → `"720h"` (30 days)

## Test plan
- [x] All existing tests updated and passing
- [x] Verified edge cases like negative values and decimal precision
- [x] Confirmed proper rounding behavior for all fractional hours
- [x] Validated consistent "Xh" format across all time ranges