### PR TITLE
feat: enhance formatHours to optionally include minutes

### DIFF
--- a/web/js/Chart.js
+++ b/web/js/Chart.js
@@ -77,7 +77,7 @@ const tooltipFormatters = {
   formatBytes,
   formatMilliseconds,
   formatSeconds,
-  formatHours,
+  formatHours: (value) => formatHours(value, { includeMinutes: true }),
 };
 
 function locale() {
@@ -385,7 +385,6 @@ function tooltipSeries({ color, seriesName, value }, options = {}) {
   if (options.valueFormat && typeof options.valueFormat === "string") {
     if (options.valueFormat.startsWith("fn:")) {
       const functionName = options.valueFormat.substring(3);
-      tooltipFormatters[functionName]();
       if (functionName in tooltipFormatters) {
         formattedValue = tooltipFormatters[functionName](value);
       }

--- a/web/js/formatters.js
+++ b/web/js/formatters.js
@@ -1,9 +1,28 @@
 /**
  * Formats hours into a human readable string
  * @param {number} hours - The time duration in hours
- * @returns {string} Formatted time string (e.g., "1h", "25h", "168h")
+ * @param {Object} options - Formatting options
+ * @param {boolean} [options.includeMinutes=false] - Whether to include minutes in the output
+ * @returns {string} Formatted time string (e.g., "1h", "1h 30m", "25h", "168h")
  */
-export function formatHours(hours) {
-  const wholeHours = Math.round(hours);
-  return `${wholeHours}h`;
+export function formatHours(hours, options = {}) {
+  const { includeMinutes = false } = options;
+
+  if (!includeMinutes) {
+    const wholeHours = Math.round(hours);
+    return `${wholeHours}h`;
+  }
+
+  const isNegative = hours < 0;
+  const absHours = Math.abs(hours);
+  const wholeHours = Math.floor(absHours);
+  const minutes = Math.round((absHours - wholeHours) * 60);
+
+  if (minutes === 0) {
+    return `${isNegative ? "-" : ""}${wholeHours}h`;
+  } else if (minutes === 60) {
+    return `${isNegative ? "-" : ""}${wholeHours + 1}h`;
+  } else {
+    return `${isNegative ? "-" : ""}${wholeHours}h ${minutes}m`;
+  }
 }

--- a/web/js/formatters.test.js
+++ b/web/js/formatters.test.js
@@ -73,4 +73,50 @@ describe("formatHours", () => {
       expect(formatHours(23.9999)).toBe("24h");
     });
   });
+
+  describe("with includeMinutes option", () => {
+    it("formats hours with minutes when includeMinutes is true", () => {
+      expect(formatHours(1.5, { includeMinutes: true })).toBe("1h 30m");
+      expect(formatHours(2.25, { includeMinutes: true })).toBe("2h 15m");
+      expect(formatHours(3.75, { includeMinutes: true })).toBe("3h 45m");
+    });
+
+    it("formats whole hours without minutes", () => {
+      expect(formatHours(1, { includeMinutes: true })).toBe("1h");
+      expect(formatHours(5, { includeMinutes: true })).toBe("5h");
+      expect(formatHours(24, { includeMinutes: true })).toBe("24h");
+    });
+
+    it("rounds minutes correctly", () => {
+      expect(formatHours(1.501, { includeMinutes: true })).toBe("1h 30m");
+      expect(formatHours(1.499, { includeMinutes: true })).toBe("1h 30m");
+      expect(formatHours(1.008, { includeMinutes: true })).toBe("1h");
+    });
+
+    it("handles edge case where minutes round to 60", () => {
+      expect(formatHours(1.999, { includeMinutes: true })).toBe("2h");
+      expect(formatHours(23.999, { includeMinutes: true })).toBe("24h");
+    });
+
+    it("works with large hour values", () => {
+      expect(formatHours(25.5, { includeMinutes: true })).toBe("25h 30m");
+      expect(formatHours(168.25, { includeMinutes: true })).toBe("168h 15m");
+      expect(formatHours(720.75, { includeMinutes: true })).toBe("720h 45m");
+    });
+
+    it("handles negative values with minutes", () => {
+      expect(formatHours(-1.5, { includeMinutes: true })).toBe("-1h 30m");
+      expect(formatHours(-24.25, { includeMinutes: true })).toBe("-24h 15m");
+    });
+
+    it("uses default behavior when includeMinutes is false", () => {
+      expect(formatHours(1.5, { includeMinutes: false })).toBe("2h");
+      expect(formatHours(2.25, { includeMinutes: false })).toBe("2h");
+    });
+
+    it("uses default behavior when no options provided", () => {
+      expect(formatHours(1.5)).toBe("2h");
+      expect(formatHours(2.25)).toBe("2h");
+    });
+  });
 });


### PR DESCRIPTION
## Summary
- Enhanced the `formatHours` function to optionally display minutes in addition to hours
- Updated Chart.js tooltip formatter to use the new feature for better time precision
- Added comprehensive test coverage for the new functionality

## Changes
- Added `includeMinutes` option to `formatHours` function that formats time as "Xh Ym" when enabled
- Modified Chart.js to pass `{ includeMinutes: true }` to the formatHours tooltip formatter
- Added extensive tests covering various scenarios including edge cases and negative values

## Test plan
- [x] Run existing tests to ensure backward compatibility
- [x] Added new tests for the includeMinutes option
- [x] Tested with various hour values including decimals, whole numbers, and edge cases
- [x] Verified Chart.js tooltip formatting works correctly with the new option