### PR TITLE
feat: add passthrough component

### DIFF
--- a/.github/workflows/conventional-pr.yml
+++ b/.github/workflows/conventional-pr.yml
@@ -13,8 +13,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: CondeNast/conventional-pull-request-action@v0.2.0
+      - uses: amannn/action-semantic-pull-request@v5
+        with:
+          requireScope: false
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          commitTitleMatch: false

--- a/Package.resolved
+++ b/Package.resolved
@@ -14,8 +14,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/onevcat/Rainbow",
       "state" : {
-        "revision" : "0c627a4f8a39ef37eadec1ceec02e4a7f55561ac",
-        "version" : "4.1.0"
+        "revision" : "16da5c62dd737258c6df2e8c430f8a3202f655a7",
+        "version" : "4.2.0"
       }
     },
     {
@@ -32,8 +32,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-log",
       "state" : {
-        "revision" : "3d8596ed08bd13520157f0355e35caed215ffbfa",
-        "version" : "1.6.3"
+        "revision" : "ce592ae52f982c847a4efc0dd881cc9eb32d29f2",
+        "version" : "1.6.4"
       }
     }
   ],

--- a/cli/Sources/Noora/Noora.swift
+++ b/cli/Sources/Noora/Noora.swift
@@ -80,6 +80,12 @@ public struct InfoAlert: ExpressibleByStringLiteral, ExpressibleByStringInterpol
 }
 
 public protocol Noorable {
+    /// Outputs the given text through the given pipeline.
+    /// - Parameters:
+    ///   - text: The text to pass through the given pipeline.
+    ///   - pipeline: The pipeline to send the text through.
+    func passthrough(_ text: TerminalText, pipeline: StandardPipelineType)
+
     /// It shows multiple options to the user to select one.
     /// - Parameters:
     ///   - title: A title that captures what's being asked.
@@ -739,6 +745,15 @@ public class Noora: Noorable {
         )
     }
 
+    public func passthrough(_ text: TerminalText, pipeline: StandardPipelineType) {
+        switch pipeline {
+        case .error:
+            standardPipelines.error.write(content: text.formatted(theme: theme, terminal: terminal))
+        case .output:
+            standardPipelines.output.write(content: text.formatted(theme: theme, terminal: terminal))
+        }
+    }
+
     /// Helper method to convert simple string arrays to TableData
     private func createTableData(headers: [String], rows: [[String]]) -> TableData {
         // Create columns with automatic width and left alignment by default
@@ -776,6 +791,12 @@ public class Noora: Noorable {
 }
 
 extension Noorable {
+    /// Writes a terminal text into the standard ouptut pipeline.
+    /// - Parameter text: The text to write.
+    public func passthrough(_ text: TerminalText) {
+        passthrough(text, pipeline: .output)
+    }
+
     public func singleChoicePrompt<T>(
         title: TerminalText? = nil,
         question: TerminalText,

--- a/cli/Sources/Noora/NooraMock.swift
+++ b/cli/Sources/Noora/NooraMock.swift
@@ -29,6 +29,8 @@
         CustomStringConvertible
     {
         private let noora: Noorable
+        private let theme: Theme
+        private let terminal: Terminaling
         private var standardPipelineEventsRecorder = StandardPipelineEventsRecorder()
 
         public var description: String {
@@ -49,9 +51,18 @@
         }
 
         public init(theme: Theme = .default, terminal: Terminaling = Terminal()) {
+            self.theme = theme
+            self.terminal = terminal
             noora = Noora(theme: theme, terminal: terminal, standardPipelines: StandardPipelines(
                 output: StandardPipeline(type: .output, eventsRecorder: standardPipelineEventsRecorder),
                 error: StandardPipeline(type: .error, eventsRecorder: standardPipelineEventsRecorder)
+            ))
+        }
+
+        public func passthrough(_ text: TerminalText, pipeline: StandardPipelineType) {
+            standardPipelineEventsRecorder.events.append(.init(
+                type: pipeline,
+                content: text.formatted(theme: theme, terminal: terminal)
             ))
         }
 
@@ -362,18 +373,6 @@
         private struct StandardOutputEvent: Equatable {
             let type: StandardPipelineType
             let content: String
-        }
-
-        private enum StandardPipelineType: CustomStringConvertible {
-            public var description: String {
-                switch self {
-                case .error: "stderr"
-                case .output: "stdout"
-                }
-            }
-
-            case output
-            case error
         }
 
         private struct StandardPipeline: StandardPipelining {

--- a/cli/Sources/Noora/StandardPipelineType.swift
+++ b/cli/Sources/Noora/StandardPipelineType.swift
@@ -1,0 +1,11 @@
+public enum StandardPipelineType: CustomStringConvertible {
+    public var description: String {
+        switch self {
+        case .error: "stderr"
+        case .output: "stdout"
+        }
+    }
+
+    case output
+    case error
+}

--- a/docs/.vitepress/config.mjs
+++ b/docs/.vitepress/config.mjs
@@ -128,6 +128,10 @@ export default defineConfig({
               },
             ],
           },
+          {
+            text: "Other",
+            link: "/components/other",
+          },
         ],
       },
       {

--- a/docs/content/components/other.md
+++ b/docs/content/components/other.md
@@ -1,0 +1,44 @@
+---
+title: Other
+titleTemplate: ":title · Noora · Tuist"
+description: Other components.
+---
+
+# Other components
+
+This section contains utility components that don't fit into other categories.
+
+## Passthrough
+
+The passthrough component allows you to write text directly to standard output or standard error pipelines with Noora's formatting and styling applied.
+
+| Property | Value |
+| --- | --- |
+| Interactivity | Non-required |
+
+### API
+
+#### Example
+
+```swift
+// Write to standard output
+Noora().passthrough("Building project...", pipeline: .output)
+
+// Write to standard error
+Noora().passthrough("Error: File not found", pipeline: .error)
+
+// Using TerminalText for styled output
+let styledText: TerminalText = "Processing \(path: "/path/to/file")..."
+Noora().passthrough(styledText, pipeline: .output)
+```
+
+#### Options
+
+| Attribute | Description | Required | Default value |
+| --- | --- | --- | --- |
+| `text` | The text to output (can be plain string or TerminalText) | Yes | |
+| `pipeline` | The standard pipeline to write to (.output or .error) | Yes | |
+
+### Use Cases
+
+The passthrough component is designed for cases where you want to output text directly to stdout or stderr without wrapping it in any Noora UI components. While it preserves any styling from `TerminalText`, it doesn't add any additional formatting or structure that other Noora components would provide. This is particularly useful when writing tests, as you can use `NooraMock` to capture the output and then run assertions against it, ensuring your text appears correctly.


### PR DESCRIPTION
I was [working](https://github.com/tuist/tuist/pull/7893) on a CLI list and read interface for bundles, when I noticed the need for text output that's not captured by any of the components provided by Noora. Note that traditionally we used the Logger for that, but we agreed we'd leave logger for diagnosing purposes, while we'd treat Noora as the interface to user-facing text (UI).

To address that, I'm adding a new interface, `Noora().passthrough("...")` that outputs the given resolving the format of the provided `TerminalText` instance.