### PR TITLE
feat: Add an interface to output JSON

### DIFF
--- a/cli/Sources/Noora/Noora.swift
+++ b/cli/Sources/Noora/Noora.swift
@@ -356,6 +356,11 @@ public protocol Noorable {
         pageSize: Int,
         renderer: Rendering
     ) throws
+
+    /// Pretty prints a Codable object as JSON.
+    /// - Parameter item: The Codable object to pretty print as JSON.
+    /// - Throws: An error if the object cannot be encoded to JSON.
+    func json(_ item: some Codable) throws
 }
 
 // swiftlint:disable:next type_body_length
@@ -751,6 +756,17 @@ public class Noora: Noorable {
             standardPipelines.error.write(content: text.formatted(theme: theme, terminal: terminal))
         case .output:
             standardPipelines.output.write(content: text.formatted(theme: theme, terminal: terminal))
+        }
+    }
+
+    public func json(_ item: some Codable) throws {
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+
+        let jsonData = try encoder.encode(item)
+        if let jsonString = String(data: jsonData, encoding: .utf8) {
+            let text = TerminalText(stringLiteral: jsonString)
+            passthrough(text, pipeline: .output)
         }
     }
 

--- a/cli/Sources/Noora/NooraMock.swift
+++ b/cli/Sources/Noora/NooraMock.swift
@@ -66,6 +66,17 @@
             ))
         }
 
+        public func json(_ item: some Codable) throws {
+            let encoder = JSONEncoder()
+            encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+
+            let jsonData = try encoder.encode(item)
+            if let jsonString = String(data: jsonData, encoding: .utf8) {
+                let text = TerminalText(stringLiteral: jsonString)
+                passthrough(text, pipeline: .output)
+            }
+        }
+
         /// Deletes all the recorded output.
         public func reset() {
             standardPipelineEventsRecorder.reset()

--- a/cli/Tests/NooraTests/Components/NooraTests.swift
+++ b/cli/Tests/NooraTests/Components/NooraTests.swift
@@ -1,0 +1,162 @@
+import Testing
+@testable import Noora
+
+enum NooraTests {
+    // MARK: - JSON Function Tests
+
+    struct JSONTests {
+        let subject = NooraMock()
+
+        @Test func printsSimpleObject() throws {
+            // Given
+            struct Person: Codable {
+                let name: String
+                let age: Int
+            }
+            let person = Person(name: "John", age: 30)
+
+            // When
+            try subject.json(person)
+
+            // Then
+            #expect(subject.description == """
+            {
+              "age" : 30,
+              "name" : "John"
+            }
+            """)
+        }
+
+        @Test func printsComplexObject() throws {
+            // Given
+            struct Address: Codable {
+                let street: String
+                let city: String
+            }
+            struct Person: Codable {
+                let name: String
+                let age: Int
+                let address: Address
+            }
+            let person = Person(
+                name: "Jane",
+                age: 25,
+                address: Address(street: "123 Main St", city: "Springfield")
+            )
+
+            // When
+            try subject.json(person)
+
+            // Then
+            #expect(subject.description == """
+            {
+              "address" : {
+                "city" : "Springfield",
+                "street" : "123 Main St"
+              },
+              "age" : 25,
+              "name" : "Jane"
+            }
+            """)
+        }
+
+        @Test func printsArray() throws {
+            // Given
+            let items = ["apple", "banana", "cherry"]
+
+            // When
+            try subject.json(items)
+
+            // Then
+            #expect(subject.description == """
+            [
+              "apple",
+              "banana",
+              "cherry"
+            ]
+            """)
+        }
+
+        @Test func printsDictionary() throws {
+            // Given
+            let dict = ["key1": "value1", "key2": "value2"]
+
+            // When
+            try subject.json(dict)
+
+            // Then
+            #expect(subject.description == """
+            {
+              "key1" : "value1",
+              "key2" : "value2"
+            }
+            """)
+        }
+
+        @Test func printsNestedArraysAndDictionaries() throws {
+            // Given
+            struct SimpleData: Codable {
+                let items: [[String: String]]
+            }
+
+            let data = SimpleData(items: [
+                ["name": "item1", "type": "A"],
+                ["name": "item2", "type": "B"],
+            ])
+
+            // When
+            try subject.json(data)
+
+            // Then
+            #expect(subject.description == """
+            {
+              "items" : [
+                {
+                  "name" : "item1",
+                  "type" : "A"
+                },
+                {
+                  "name" : "item2",
+                  "type" : "B"
+                }
+              ]
+            }
+            """)
+        }
+
+        @Test func handlesEmptyObject() throws {
+            // Given
+            struct Empty: Codable {}
+            let empty = Empty()
+
+            // When
+            try subject.json(empty)
+
+            // Then
+            #expect(subject.description == """
+            {
+
+            }
+            """)
+        }
+
+        @Test func handlesOptionalValues() throws {
+            // Given
+            struct OptionalData: Codable {
+                let required: String
+                let optional: String?
+            }
+            let data = OptionalData(required: "value", optional: nil)
+
+            // When
+            try subject.json(data)
+
+            // Then
+            #expect(subject.description == """
+            {
+              "required" : "value"
+            }
+            """)
+        }
+    }
+}

--- a/docs/content/components/other.md
+++ b/docs/content/components/other.md
@@ -42,3 +42,87 @@ Noora().passthrough(styledText, pipeline: .output)
 ### Use Cases
 
 The passthrough component is designed for cases where you want to output text directly to stdout or stderr without wrapping it in any Noora UI components. While it preserves any styling from `TerminalText`, it doesn't add any additional formatting or structure that other Noora components would provide. This is particularly useful when writing tests, as you can use `NooraMock` to capture the output and then run assertions against it, ensuring your text appears correctly.
+
+## JSON
+
+The JSON component allows you to pretty print any Codable object as formatted JSON to the standard output.
+
+| Property | Value |
+| --- | --- |
+| Interactivity | Non-required |
+
+### API
+
+#### Example
+
+```swift
+// Simple struct
+struct Person: Codable {
+    let name: String
+    let age: Int
+}
+
+let person = Person(name: "John", age: 30)
+try Noora().json(person)
+// Output:
+// {
+//   "age" : 30,
+//   "name" : "John"
+// }
+
+// Arrays and dictionaries
+let items = ["apple", "banana", "cherry"]
+try Noora().json(items)
+// Output:
+// [
+//   "apple",
+//   "banana",
+//   "cherry"
+// ]
+
+// Complex nested structures
+struct Address: Codable {
+    let street: String
+    let city: String
+}
+struct Employee: Codable {
+    let name: String
+    let address: Address
+    let skills: [String]
+}
+
+let employee = Employee(
+    name: "Jane",
+    address: Address(street: "123 Main St", city: "Springfield"),
+    skills: ["Swift", "iOS", "Architecture"]
+)
+try Noora().json(employee)
+// Output:
+// {
+//   "address" : {
+//     "city" : "Springfield",
+//     "street" : "123 Main St"
+//   },
+//   "name" : "Jane",
+//   "skills" : [
+//     "Swift",
+//     "iOS",
+//     "Architecture"
+//   ]
+// }
+```
+
+#### Options
+
+| Attribute | Description | Required | Default value |
+| --- | --- | --- | --- |
+| `item` | Any Codable object to be printed as JSON | Yes | |
+
+### Use Cases
+
+The JSON component is useful for debugging and displaying structured data in a human-readable format. It automatically formats the JSON with proper indentation and sorted keys for consistency. If encoding fails, the error is thrown and should be handled by the caller. This component is particularly helpful when you need to:
+
+- Debug API responses or data models
+- Display configuration or settings in a readable format
+- Log structured data during development
+- Present JSON data to users in CLI tools


### PR DESCRIPTION
I'm adding an interface to output a JSON given a `Codable` object.

## Why this interface?
One might thin, why not just use `.passthrough` and ask the caller to do the encoding. That works too, but by owning the encoding part, we can ensure consistent formatting, and down the road, even build an interactive version of this, where the user could type to query data in the JSON dynamically.