### PR TITLE
feat: add custom JSONEncoder parameter to json() method

### DIFF
--- a/cli/Sources/Noora/Noora.swift
+++ b/cli/Sources/Noora/Noora.swift
@@ -1096,7 +1096,7 @@ extension Noorable {
     public func json(_ item: some Codable) throws {
         let encoder = JSONEncoder()
         encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
-        encoder.dateEncodingStrategy = .secondsSince1970
+        encoder.dateEncodingStrategy = .iso8601
         try json(item, encoder: encoder)
     }
 }

--- a/cli/Sources/Noora/Noora.swift
+++ b/cli/Sources/Noora/Noora.swift
@@ -359,8 +359,9 @@ public protocol Noorable {
 
     /// Pretty prints a Codable object as JSON.
     /// - Parameter item: The Codable object to pretty print as JSON.
+    /// - Parameter encoder: The encoder to use for encoding the item.
     /// - Throws: An error if the object cannot be encoded to JSON.
-    func json(_ item: some Codable) throws
+    func json(_ item: some Codable, encoder: JSONEncoder) throws
 }
 
 // swiftlint:disable:next type_body_length
@@ -759,10 +760,7 @@ public class Noora: Noorable {
         }
     }
 
-    public func json(_ item: some Codable) throws {
-        let encoder = JSONEncoder()
-        encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
-
+    public func json(_ item: some Codable, encoder: JSONEncoder) throws {
         let jsonData = try encoder.encode(item)
         if let jsonString = String(data: jsonData, encoding: .utf8) {
             let text = TerminalText(stringLiteral: jsonString)
@@ -1090,5 +1088,15 @@ extension Noorable {
             pageSize: pageSize,
             renderer: renderer
         )
+    }
+
+    /// Pretty prints a Codable object as JSON.
+    /// - Parameter item: The Codable object to pretty print as JSON.
+    /// - Throws: An error if the object cannot be encoded to JSON.
+    public func json(_ item: some Codable) throws {
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+        encoder.dateEncodingStrategy = .secondsSince1970
+        try json(item, encoder: encoder)
     }
 }

--- a/cli/Sources/Noora/NooraMock.swift
+++ b/cli/Sources/Noora/NooraMock.swift
@@ -66,10 +66,7 @@
             ))
         }
 
-        public func json(_ item: some Codable) throws {
-            let encoder = JSONEncoder()
-            encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
-
+        public func json(_ item: some Codable, encoder: JSONEncoder) throws {
             let jsonData = try encoder.encode(item)
             if let jsonString = String(data: jsonData, encoding: .utf8) {
                 let text = TerminalText(stringLiteral: jsonString)

--- a/cli/Tests/NooraTests/Components/NooraTests.swift
+++ b/cli/Tests/NooraTests/Components/NooraTests.swift
@@ -198,7 +198,7 @@ enum NooraTests {
             // Then
             #expect(subject.description == """
             {
-              "date" : 1000,
+              "date" : "1970-01-01T00:16:40Z",
               "name" : "test"
             }
             """)

--- a/cli/Tests/NooraTests/Components/NooraTests.swift
+++ b/cli/Tests/NooraTests/Components/NooraTests.swift
@@ -1,3 +1,4 @@
+import Foundation
 import Testing
 @testable import Noora
 
@@ -157,6 +158,109 @@ enum NooraTests {
               "required" : "value"
             }
             """)
+        }
+
+        @Test func usesCustomEncoder() throws {
+            // Given
+            struct DataWithDate: Codable {
+                let date: Date
+                let name: String
+            }
+            let data = DataWithDate(date: Date(timeIntervalSince1970: 1000), name: "test")
+
+            let customEncoder = Foundation.JSONEncoder()
+            customEncoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+            customEncoder.dateEncodingStrategy = .iso8601
+
+            // When
+            try subject.json(data, encoder: customEncoder)
+
+            // Then
+            #expect(subject.description == """
+            {
+              "date" : "1970-01-01T00:16:40Z",
+              "name" : "test"
+            }
+            """)
+        }
+
+        @Test func defaultEncoderUsesSecondsSince1970() throws {
+            // Given
+            struct DataWithDate: Codable {
+                let date: Date
+                let name: String
+            }
+            let data = DataWithDate(date: Date(timeIntervalSince1970: 1000), name: "test")
+
+            // When
+            try subject.json(data)
+
+            // Then
+            #expect(subject.description == """
+            {
+              "date" : 1000,
+              "name" : "test"
+            }
+            """)
+        }
+
+        @Test func customEncoderWithoutPrettyPrint() throws {
+            // Given
+            struct SimpleData: Codable {
+                let value: String
+            }
+            let data = SimpleData(value: "test")
+
+            let customEncoder = Foundation.JSONEncoder()
+            customEncoder.outputFormatting = [] // No pretty printing
+
+            // When
+            try subject.json(data, encoder: customEncoder)
+
+            // Then
+            #expect(subject.description == """
+            {"value":"test"}
+            """)
+        }
+
+        @Test func customEncoderWithCustomKeyStrategy() throws {
+            // Given
+            struct CamelCaseData: Codable {
+                let firstName: String
+                let lastName: String
+            }
+            let data = CamelCaseData(firstName: "John", lastName: "Doe")
+
+            let customEncoder = Foundation.JSONEncoder()
+            customEncoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+            customEncoder.keyEncodingStrategy = .convertToSnakeCase
+
+            // When
+            try subject.json(data, encoder: customEncoder)
+
+            // Then
+            #expect(subject.description == """
+            {
+              "first_name" : "John",
+              "last_name" : "Doe"
+            }
+            """)
+        }
+
+        @Test func encoderErrorThrows() throws {
+            // Given
+            struct InvalidData: Codable {
+                let value: Double
+            }
+            let data = InvalidData(value: .infinity)
+
+            let customEncoder = Foundation.JSONEncoder()
+            customEncoder.nonConformingFloatEncodingStrategy = .throw
+
+            // When/Then
+            #expect(throws: (any Error).self) {
+                try subject.json(data, encoder: customEncoder)
+            }
         }
     }
 }

--- a/docs/content/components/other.md
+++ b/docs/content/components/other.md
@@ -110,6 +110,55 @@ try Noora().json(employee)
 //     "Architecture"
 //   ]
 // }
+
+// Using a custom encoder
+struct DataWithDate: Codable {
+    let timestamp: Date
+    let event: String
+}
+
+let data = DataWithDate(
+    timestamp: Date(),
+    event: "User login"
+)
+
+// Default encoder uses seconds since 1970 for dates
+try Noora().json(data)
+// Output:
+// {
+//   "event" : "User login",
+//   "timestamp" : 1709500800
+// }
+
+// Custom encoder with ISO8601 date formatting
+let customEncoder = JSONEncoder()
+customEncoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+customEncoder.dateEncodingStrategy = .iso8601
+
+try Noora().json(data, encoder: customEncoder)
+// Output:
+// {
+//   "event" : "User login",
+//   "timestamp" : "2024-03-04T00:00:00Z"
+// }
+
+// Custom encoder with snake_case key conversion
+struct CamelCaseData: Codable {
+    let firstName: String
+    let lastName: String
+}
+
+let encoder = JSONEncoder()
+encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+encoder.keyEncodingStrategy = .convertToSnakeCase
+
+let userData = CamelCaseData(firstName: "John", lastName: "Doe")
+try Noora().json(userData, encoder: encoder)
+// Output:
+// {
+//   "first_name" : "John",
+//   "last_name" : "Doe"
+// }
 ```
 
 #### Options
@@ -117,12 +166,23 @@ try Noora().json(employee)
 | Attribute | Description | Required | Default value |
 | --- | --- | --- | --- |
 | `item` | Any Codable object to be printed as JSON | Yes | |
+| `encoder` | Custom JSONEncoder to control formatting | No | JSONEncoder with `.prettyPrinted`, `.sortedKeys`, and `.secondsSince1970` date encoding |
 
 ### Use Cases
 
-The JSON component is useful for debugging and displaying structured data in a human-readable format. It automatically formats the JSON with proper indentation and sorted keys for consistency. If encoding fails, the error is thrown and should be handled by the caller. This component is particularly helpful when you need to:
+The JSON component is useful for debugging and displaying structured data in a human-readable format. By default, it formats the JSON with proper indentation and sorted keys for consistency. The custom encoder parameter allows you to:
+
+- Control date formatting (ISO8601, seconds since 1970, custom formats)
+- Convert property names (camelCase to snake_case)
+- Customize output formatting (compact vs pretty printed)
+- Handle special floating-point values (infinity, NaN)
+- Apply custom encoding strategies for specific types
+
+This component is particularly helpful when you need to:
 
 - Debug API responses or data models
 - Display configuration or settings in a readable format
 - Log structured data during development
 - Present JSON data to users in CLI tools
+- Export data in formats required by external systems
+- Ensure consistent JSON output across your application


### PR DESCRIPTION
While working on the list and show CLI interface for bundles, I noticed that with the `.json()` interface, the dates were not properly formatted. This PR sets the default to using unix timestamp, and adds a new function where the caller can pass the `JSONEncoder` to use.

## Summary (Claude)

- Added optional `encoder` parameter to the `json()` method in the `Noorable` protocol
- Maintains backward compatibility with a default implementation that uses the existing behavior
- Allows users to customize JSON output formatting for their specific needs

## Changes

### Core Implementation
- Modified `json()` method signature to accept optional `JSONEncoder` parameter
- Added default implementation in protocol extension with:
  - `.prettyPrinted` and `.sortedKeys` output formatting
  - `.secondsSince1970` date encoding strategy
- Updated `NooraMock` to match the new protocol signature

### Tests
Added comprehensive test coverage for:
- Default encoder behavior (maintains existing functionality)
- Custom date encoding strategies (ISO8601 vs seconds since 1970)
- Custom key encoding strategies (camelCase to snake_case)
- Custom output formatting (compact vs pretty printed)
- Error handling for non-conforming float values

### Documentation
Updated the JSON component documentation with:
- Examples showing custom encoder usage
- Clear explanation of the default encoder settings
- Use cases for customization

## Test Plan

- [x] All existing tests pass
- [x] New tests added for custom encoder functionality
- [x] Linting passes (`mise run cli:lint`)
- [x] Documentation updated with examples

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Added support for customizing JSON encoding by allowing users to provide their own JSONEncoder when generating JSON output.

* **Documentation**
  * Updated documentation with examples and explanations on using custom JSONEncoder configurations, including date formatting and key naming strategies.

* **Tests**
  * Added new test cases to verify JSON encoding with various encoder configurations and error scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->