### PR TITLE
feat: make TerminalSize properties public

### DIFF
--- a/cli/Sources/Noora/Utilities/Terminal.swift
+++ b/cli/Sources/Noora/Utilities/Terminal.swift
@@ -17,8 +17,13 @@ public protocol Terminaling {
 }
 
 public struct TerminalSize {
-    let rows: Int
-    let columns: Int
+    public let rows: Int
+    public let columns: Int
+
+    public init(rows: Int, columns: Int) {
+        self.rows = rows
+        self.columns = columns
+    }
 }
 
 public struct Terminal: Terminaling {


### PR DESCRIPTION
allow clients to query the current terminal size. The type itself was already public, this ensures we can also access its properties.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Exposes terminal size details to external integrations. Plugins and scripts can now read terminal rows and columns and create terminal size instances directly, enabling better layout-aware behaviors in extensions and tooling.
  * Improves interoperability for developers building on top of the CLI by providing a clearer, supported way to access terminal dimensions without workarounds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->