### PR TITLE
fix(web): ensure tab menu icons have the right color

### DIFF
--- a/web/css/tab-menu.css
+++ b/web/css/tab-menu.css
@@ -68,8 +68,9 @@
 
   & > [data-part="icon-left"],
   & > [data-part="icon-right"] {
-    width: 18px;
+    color: var(--noora-surface-label-secondary);
     height: 18px;
+    width: 18px;
 
     & svg {
       width: 100%;


### PR DESCRIPTION
the default `a` tag color was overriding the icon slot color.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated tab menu item icons to use the secondary label color, improving visual consistency and contrast.
  * Preserved icon dimensions for a stable, balanced layout in horizontal tab menus.
  * Enhances readability and aligns icon appearance with the overall theme without altering behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->