### PR TITLE
feat: add text area component

### DIFF
--- a/storybook/storybook/text_area.story.exs
+++ b/storybook/storybook/text_area.story.exs
@@ -1,0 +1,57 @@
+defmodule TuistWeb.Storybook.TextArea do
+  @moduledoc false
+  use PhoenixStorybook.Story, :component
+
+  def function, do: &Noora.TextArea.text_area/1
+
+  def variations do
+    [
+      %Variation{
+        id: :basic,
+        attributes: %{
+          name: "basic",
+          placeholder: "Enter your message...",
+          max_length: 200
+        }
+      },
+      %Variation{
+        id: :required,
+        attributes: %{
+          name: "required",
+          label: "Message",
+          placeholder: "This field is required",
+          required: true,
+          show_required: true
+        }
+      },
+      %Variation{
+        id: :with_hint,
+        attributes: %{
+          name: "with_hint",
+          label: "Feedback",
+          placeholder: "Share your feedback...",
+          hint: "Please be as detailed as possible"
+        }
+      },
+      %Variation{
+        id: :error,
+        attributes: %{
+          name: "error",
+          label: "Message",
+          placeholder: "Enter your message...",
+          error: "This field is required",
+          value: ""
+        }
+      },
+      %Variation{
+        id: :disabled,
+        attributes: %{
+          name: "disabled",
+          label: "Disabled",
+          placeholder: "Enter your message...",
+          disabled: true
+        }
+      },
+    ]
+  end
+end

--- a/web/css/index.css
+++ b/web/css/index.css
@@ -23,6 +23,7 @@
 @import "./tab-menu.css";
 @import "./table.css";
 @import "./tag.css";
+@import "./text-area.css";
 @import "./text-divider.css";
 @import "./text-input.css";
 @import "./time.css";

--- a/web/css/label.css
+++ b/web/css/label.css
@@ -15,4 +15,10 @@
     color: var(--noora-surface-label-secondary);
     font: var(--noora-font-body-medium);
   }
+
+  &[disabled] label,
+  &[disabled] [data-part="required-indicator"],
+  &[disabled] [data-part="sublabel"] {
+    color: var(--noora-surface-label-disabled);
+  }
 }

--- a/web/css/text-area.css
+++ b/web/css/text-area.css
@@ -1,0 +1,85 @@
+.noora-text-area {
+  display: flex;
+  flex-direction: column;
+  align-self: stretch;
+  gap: var(--noora-spacing-3);
+
+  & > [data-part="wrapper"] {
+    padding: var(--noora-spacing-5);
+    box-shadow: var(--noora-border-light-default);
+    border-radius: var(--noora-radius-medium);
+    background: var(--noora-surface-background-primary);
+    display: flex;
+    position: relative;
+  }
+
+  &[disabled] > [data-part="wrapper"] {
+    background: var(--noora-surface-background-secondary);
+  }
+
+  &:not([disabled]) {
+    & > [data-part="wrapper"] {
+      cursor: text;
+
+      &:hover,
+      &:focus {
+        background: var(--noora-surface-background-secondary);
+        box-shadow: var(--noora-light-border-focus);
+      }
+    }
+  }
+
+  &[data-error] > [data-part="wrapper"] {
+    box-shadow: var(--noora-border-light-error);
+
+    &:hover {
+      box-shadow: var(--noora-border-light-error-focus);
+    }
+  }
+
+  & textarea {
+    flex-grow: 1;
+    outline: none;
+    border: none;
+    background: none;
+    color: var(--noora-surface-label-primary);
+    font: var(--noora-font-weight-regular) var(--noora-font-body-medium);
+    &::-webkit-resizer {
+      background-image: url('data:image/svg+xml;utf8,<svg width="12" height="12" viewBox="0 0 12 12" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M9.11111 2L2 9.11111M10 6.44444L6.44444 10" stroke="%23848F9A"/></svg>');
+      background-position: bottom;
+      background-repeat: no-repeat;
+    }
+
+    &:not(:disabled)::placeholder {
+      color: var(--noora-surface-label-tertiary);
+    }
+
+    &:disabled::placeholder {
+      color: var(--noora-surface-label-disabled);
+    }
+  }
+
+  &[data-error] textarea::-webkit-resizer {
+    background-image: url('data:image/svg+xml;utf8,<svg width="12" height="12" viewBox="0 0 12 12" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M9.11111 2L2 9.11111M10 6.44444L6.44444 10" stroke="%23E34935"/></svg>');
+  }
+
+  &[disabled] textarea::-webkit-resizer {
+    background-image: url('data:image/svg+xml;utf8,<svg width="12" height="12" viewBox="0 0 12 12" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M9.11111 2L2 9.11111M10 6.44444L6.44444 10" stroke="%23C0C6D0"/></svg>');
+  }
+
+  & [data-part="character-count"] {
+    position: absolute;
+    bottom: var(--noora-spacing-5);
+    right: 30px;
+    font: var(--noora-font-weight-medium) var(--noora-font-body-xsmall);
+    color: var(--noora-surface-label-secondary);
+  }
+
+  &[data-error] [data-part="character-count"] {
+    color: var(--noora-surface-label-destructive);
+  }
+
+  &[disabled] [data-part="character-count"] {
+    color: var(--noora-surface-label-disabled);
+  }
+}

--- a/web/lib/noora.ex
+++ b/web/lib/noora.ex
@@ -34,6 +34,7 @@ defmodule Noora do
       import Noora.Table
       import Noora.TabMenu
       import Noora.Tag
+      import Noora.TextArea
       import Noora.TextDivider
       import Noora.TextInput
       import Noora.Tooltip

--- a/web/lib/noora/label.ex
+++ b/web/lib/noora/label.ex
@@ -14,12 +14,13 @@ defmodule Noora.Label do
   attr(:label, :string, required: true, doc: "The label")
   attr(:sublabel, :string, default: nil, doc: "A sublabel")
   attr(:required, :boolean, default: false, doc: "Whether the field is required")
+  attr(:disabled, :boolean, default: false, doc: "Whether the label is disabled")
 
   attr(:rest, :global, doc: "Additional HTML attributes")
 
   def label(assigns) do
     ~H"""
-    <div class="noora-label">
+    <div class="noora-label" disabled={@disabled}>
       <label {@rest}>
         {@label}
       </label>

--- a/web/lib/noora/text_area.ex
+++ b/web/lib/noora/text_area.ex
@@ -43,6 +43,7 @@ defmodule Noora.TextArea do
 
   attr(:rows, :integer, default: 4, doc: "Number of visible text lines for the textarea.")
   attr(:max_length, :integer, default: 200, doc: "Maximum number of characters allowed.")
+  attr(:show_character_count, :boolean, default: true, doc: "Whether to show the character count.")
 
   attr(:resize, :string,
     values: ~w(none both horizontal vertical),
@@ -73,8 +74,12 @@ defmodule Noora.TextArea do
       |> assign_new(:id, fn -> "text-area-#{System.unique_integer([:positive])}" end)
 
     character_count = String.length(assigns.value || "")
+    resize = if assigns.disabled, do: "none", else: assigns.resize
 
-    assigns = assign(assigns, :character_count, character_count)
+    assigns =
+      assigns
+      |> assign(:character_count, character_count)
+      |> assign(:resize, resize)
 
     ~H"""
     <div class="noora-text-area" data-error={@error} disabled={@disabled}>
@@ -98,7 +103,7 @@ defmodule Noora.TextArea do
           disabled={@disabled}
           {@rest}
         >{@value}</textarea>
-        <span data-part="character-count">
+        <span :if={@show_character_count && !@disabled} data-part="character-count">
           {@character_count}/{@max_length}
         </span>
       </div>

--- a/web/lib/noora/text_area.ex
+++ b/web/lib/noora/text_area.ex
@@ -1,0 +1,111 @@
+defmodule Noora.TextArea do
+  @moduledoc """
+  Renders textarea components with customizable labels, placeholders, character counting, and event handling.
+
+  ## Example
+
+  ```elixir
+  <.text_area name="description" label="Description" placeholder="Enter description" />
+  <.text_area name="message" label="Message" required={true} show_required={true} />
+  <.text_area name="notes" label="Notes" hint="Additional information" />
+  <.text_area name="content" label="Content" max_length={500} />
+  ```
+  """
+  use Phoenix.Component
+
+  import Noora.HintText
+  import Noora.Label
+
+  alias Phoenix.HTML.FormField
+  alias Phoenix.LiveView.JS
+
+  attr(:id, :string, required: false)
+
+  attr(:field, FormField, doc: "A Phoenix form field")
+
+  attr(:label, :string, default: nil, doc: "Label to be rendered above the textarea.")
+  attr(:sublabel, :string, default: nil, doc: "Sublabel to be rendered above the textarea.")
+  attr(:hint, :string, default: nil, doc: "Hint text to be rendered below the textarea.")
+  attr(:hint_variant, :string, default: "default", doc: "Hint text variant.")
+
+  attr(:error, :string, doc: "Errors to be rendered below the textarea. Takes precedence over `hint`.")
+
+  attr(:show_error_message, :boolean,
+    default: true,
+    doc: "Whether to show the error message below the textarea."
+  )
+
+  attr(:name, :string, doc: "The name of the textarea")
+  attr(:value, :string, doc: "The value of the textarea")
+  attr(:placeholder, :string, default: nil, doc: "Placeholder text to be rendered in the textarea.")
+  attr(:required, :boolean, default: false, doc: "Whether the textarea is required.")
+  attr(:show_required, :boolean, default: false, doc: "Whether the required indicator is shown.")
+
+  attr(:rows, :integer, default: 4, doc: "Number of visible text lines for the textarea.")
+  attr(:max_length, :integer, default: 200, doc: "Maximum number of characters allowed.")
+
+  attr(:resize, :string,
+    values: ~w(none both horizontal vertical),
+    default: "vertical",
+    doc: "CSS resize property for the textarea."
+  )
+
+  attr(:disabled, :boolean, default: false, doc: "Whether the textarea is disabled.")
+
+  attr(:rest, :global)
+
+  def text_area(%{field: %FormField{} = field} = assigns) do
+    assigns
+    |> assign(field: nil, id: Map.get(assigns, :id, field.id))
+    |> assign_new(:name, fn -> field.name end)
+    |> assign_new(:value, fn -> field.value end)
+    |> assign_new(:error, fn ->
+      field.errors |> Enum.map(fn {message, _opts} -> message end) |> List.first()
+    end)
+    |> text_area()
+  end
+
+  def text_area(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:value, fn -> "" end)
+      |> assign_new(:error, fn -> nil end)
+      |> assign_new(:id, fn -> "text-area-#{System.unique_integer([:positive])}" end)
+
+    character_count = String.length(assigns.value || "")
+
+    assigns = assign(assigns, :character_count, character_count)
+
+    ~H"""
+    <div class="noora-text-area" data-error={@error} disabled={@disabled}>
+      <.label
+        :if={@label}
+        label={@label}
+        sublabel={@sublabel}
+        required={@required and @show_required}
+        disabled={@disabled}
+        data-part="label"
+      />
+      <div data-part="wrapper" phx-click={JS.focus(to: "##{@id}")}>
+        <textarea
+          id={@id}
+          name={@name}
+          rows={@rows}
+          required={@required}
+          placeholder={@placeholder}
+          maxlength={@max_length}
+          style={"resize: #{@resize}"}
+          disabled={@disabled}
+          {@rest}
+        >{@value}</textarea>
+        <span data-part="character-count">
+          {@character_count}/{@max_length}
+        </span>
+      </div>
+
+      <.hint_text :if={!is_nil(@error) and @show_error_message} label={@error} variant="destructive" />
+      <.hint_text :if={is_nil(@error) and @hint} label={@hint} variant={@hint_variant} />
+    </div>
+    """
+  end
+end


### PR DESCRIPTION
Adds the Text Area component from the design system:
<img width="1364" height="811" alt="image" src="https://github.com/user-attachments/assets/acf95231-8cb2-4e9d-bb2e-73fb8d3fa40a" />
