### PR TITLE
fix: make label disabled when text input is disabled

### DIFF
--- a/storybook/storybook/text_input.story.exs
+++ b/storybook/storybook/text_input.story.exs
@@ -114,6 +114,7 @@ defmodule TuistWeb.Storybook.TextInput do
             attributes: %{
               type: "email",
               name: "email",
+              label: "Email",
               placeholder: "hello@tuist.dev",
               suffix_hint: "This should be a valid email address ending in `@tuist.dev`.",
               disabled: true

--- a/web/lib/noora/text_input.ex
+++ b/web/lib/noora/text_input.ex
@@ -73,6 +73,8 @@ defmodule Noora.TextInput do
   attr(:max, :any, default: nil, doc: "Maximum value for number inputs.")
   attr(:step, :any, default: nil, doc: "Step value for number inputs.")
 
+  attr(:disabled, :boolean, default: false, doc: "Whether the input is disabled.")
+
   attr(:rest, :global)
 
   slot(:prefix,
@@ -110,6 +112,7 @@ defmodule Noora.TextInput do
         label={@label}
         sublabel={@sublabel}
         required={@required and @show_required}
+        disabled={@disabled}
         data-part="label"
       />
       <div


### PR DESCRIPTION
Sets the label as disabled when the text input is disabled as per the design: https://www.figma.com/design/AOrO3lGZvGvtD6hA6nIQmb/Noora-Design-System?node-id=967-2161&t=cQRoNknrxvvRxzEH-11