### PR TITLE
feat: add icon slot to inline_dropdown

### DIFF
--- a/storybook/storybook/inline_dropdown.story.exs
+++ b/storybook/storybook/inline_dropdown.story.exs
@@ -1,0 +1,91 @@
+defmodule TuistWeb.Storybook.InlineDropdown do
+  @moduledoc false
+  use PhoenixStorybook.Story, :component
+
+  alias Noora.Dropdown
+
+  def function, do: &Dropdown.inline_dropdown/1
+
+  def imports, do: [{Dropdown, [dropdown_item: 1]}, {Noora.Icon, [category: 1, chevron_right: 1]}]
+
+  def variations do
+    [
+      %Variation{
+        id: :default,
+        attributes: %{
+          label: "Inline Dropdown"
+        },
+        slots: [
+          """
+          <.dropdown_item value="1" label="Item 1" />
+          <.dropdown_item value="2" label="Item 2"><:right_icon><.chevron_right /></:right_icon></.dropdown_item>
+          <.dropdown_item value="3" label="Item 3" secondary_text="Foo" />
+          <.dropdown_item value="4" label="Item 4"><:left_icon><.category /></:left_icon></.dropdown_item>
+          <.dropdown_item value="5" label="Item 5" />
+          """
+        ]
+      },
+      %Variation{
+        id: :disabled,
+        attributes: %{
+          label: "Inline Dropdown",
+          disabled: true
+        }
+      },
+      %Variation{
+        id: :large_items,
+        attributes: %{
+          label: "Inline Dropdown with large items"
+        },
+        slots: [
+          """
+          <.dropdown_item value="1" label="Item 1" size="large">
+          <:left_icon><.category /></:left_icon>
+          </.dropdown_item>
+          <.dropdown_item value="2" label="Item 2" size="large" right_icon={false}>
+          <:left_icon><.category /></:left_icon>
+          </.dropdown_item>
+          <.dropdown_item value="3" label="Item 3" size="large" secondary_text="Foo">
+          <:left_icon><.category /></:left_icon>
+          </.dropdown_item>
+          <.dropdown_item value="4" label="Item 4" size="large">
+          <:left_icon><.category /></:left_icon>
+          </.dropdown_item>
+          <.dropdown_item value="5" label="Item 5" size="large">
+          <:left_icon><.category /></:left_icon>
+          </.dropdown_item>
+          """
+        ]
+      },
+      %Variation{
+        id: :with_icon,
+        description: "Inline dropdown with icon",
+        attributes: %{
+          label: "Options"
+        },
+        slots: [
+          """
+          <:icon><.category /></:icon>
+          <.dropdown_item value="1" label="Item 1"/>
+          <.dropdown_item value="2" label="Item 2"/>
+          <.dropdown_item value="3" label="Item 3"/>
+          """
+        ]
+      },
+      %Variation{
+        id: :with_secondary_text,
+        description: "Inline dropdown with secondary_text in items",
+        attributes: %{
+          label: "Options"
+        },
+        slots: [
+          """
+          <.dropdown_item value="1" label="Item 1" secondary_text="Foo"/>
+          <.dropdown_item value="2" label="Item 2" secondary_text="Bar"/>
+          <.dropdown_item value="3" label="Item 3" secondary_text="Baz"/>
+          """
+        ]
+      }
+    ]
+  end
+end

--- a/web/css/dropdown.css
+++ b/web/css/dropdown.css
@@ -191,6 +191,17 @@
       font: var(--noora-font-weight-medium) var(--noora-font-body-small);
     }
 
+    & > [data-part="icon"] {
+      width: var(--noora-icon-size-medium);
+      height: var(--noora-icon-size-medium);
+      color: var(--noora-surface-label-secondary);
+
+      & svg {
+        width: 100%;
+        height: 100%;
+      }
+    }
+
     & [data-part="indicator"] {
       display: inline-flex;
       color: var(--noora-surface-label-secondary);

--- a/web/lib/noora/dropdown.ex
+++ b/web/lib/noora/dropdown.ex
@@ -151,6 +151,7 @@ defmodule Noora.Dropdown do
     doc: "Function called when an interaction happens outside the component"
   )
 
+  slot(:icon, doc: "Icon to be rendered in the dropdown trigger")
   slot(:inner_block, doc: "Content to be rendered inside the dropdown menu")
 
   def inline_dropdown(assigns) do
@@ -171,6 +172,9 @@ defmodule Noora.Dropdown do
       data-on-interact-outside={@on_interact_outside}
     >
       <button data-part="trigger" disabled={@disabled}>
+        <div :if={has_slot_content?(@icon, assigns)} data-part="icon">
+          {render_slot(@icon)}
+        </div>
         <span data-part="label">{@label}</span>
         <div data-part="indicator">
           <div data-part="indicator-down">


### PR DESCRIPTION
The `inline_dropdown` currently doesn't support an icon which we need for the QA timeline.