### PR TITLE
fix: use portal to keep modal JS state stable

### DIFF
--- a/web/lib/noora/modal.ex
+++ b/web/lib/noora/modal.ex
@@ -69,6 +69,9 @@ defmodule Noora.Modal do
 
   def modal(assigns) do
     ~H"""
+    <.portal id={@id <> "-portal"} target={"#" <> @id <> "-body"}>
+      {render_slot(@inner_block)}
+    </.portal>
     <div
       id={@id}
       class="noora-modal"
@@ -76,6 +79,7 @@ defmodule Noora.Modal do
       data-close-on-escape
       data-close-on-interact-outside
       data-on-open-change={@on_open_change}
+      phx-update="ignore"
     >
       {render_slot(@trigger, %{"data-part" => "trigger"})}
       <div data-part="backdrop"></div>
@@ -92,7 +96,7 @@ defmodule Noora.Modal do
             <:header_button>{render_slot(@header_button)}</:header_button>
             {render_slot(@header_icon)}
           </.modal_header>
-          <div data-part="body">{render_slot(@inner_block)}</div>
+          <div id={@id <> "-body"} data-part="body"></div>
           <div :if={has_slot_content?(@footer, assigns)}>{render_slot(@footer)}</div>
         </div>
       </div>


### PR DESCRIPTION
Similar to: https://github.com/tuist/Noora/pull/550

We need to ensure the LiveView doesn't mess with the Modal JS state when doing updates. For Modal, we can use a portal, so that what's inside the portal (the modal body) is updated by phoenix (such as when changing a dropdown value), while the modal itself doesn't react to Phoenix updates.