### PR TITLE
fix: render icon in badge_cell slot only if needed

### DIFF
--- a/web/lib/noora/table.ex
+++ b/web/lib/noora/table.ex
@@ -221,8 +221,8 @@ defmodule Noora.Table do
     ~H"""
     <div data-part="cell" data-type="badge" {@rest}>
       <.badge style={@style} color={@color} size="large" label={@label}>
-        <:icon>
-          <.icon :if={@icon} name={@icon} />
+        <:icon :if={@icon}>
+          <.icon name={@icon} />
         </:icon>
       </.badge>
     </div>


### PR DESCRIPTION
We currently render the slot for `:icon` even if not passed to the `badge_cell`, leading to leading empty space in the badge.

Before:
<img width="1376" height="802" alt="image" src="https://github.com/user-attachments/assets/0d7dac38-a024-4e2c-8942-457427454e0e" />

After:
<img width="1376" height="802" alt="image" src="https://github.com/user-attachments/assets/6822688b-d7eb-47ba-8357-e86c02554f36" />
