### PR TITLE
fix: text_input disabled mode

### DIFF
--- a/web/css/text_input.css
+++ b/web/css/text_input.css
@@ -22,6 +22,10 @@
       background: none;
       font: var(--noora-font-body-medium);
 
+      &:disabled {
+        cursor: not-allowed;
+      }
+
       &:not(:disabled) {
         color: var(--noora-surface-label-primary);
       }

--- a/web/lib/noora/text_input.ex
+++ b/web/lib/noora/text_input.ex
@@ -137,6 +137,7 @@ defmodule Noora.TextInput do
           min={@min}
           max={@max}
           step={@step}
+          disabled={@disabled}
           {@rest}
         />
         {# Suffix hint tooltip #}


### PR DESCRIPTION
We were not passing the `disabled` value to the `input` _and_ not setting the `not-allowed` pointer when the `input` is disabled.

Before:
<img width="1116" height="402" alt="image" src="https://github.com/user-attachments/assets/5f454a86-1b45-48ab-b495-1a337116408d" />

After:
<img width="1116" height="402" alt="image" src="https://github.com/user-attachments/assets/852eeb47-ec20-4b45-8cba-2a9e559eb920" />
