### PR TITLE
fix: ci release race condition

### DIFF
--- a/.github/workflows/release-web.yml
+++ b/.github/workflows/release-web.yml
@@ -88,7 +88,7 @@ jobs:
           cd web
           mix local.hex --force
           mix local.rebar --force
-          mix hex.publish --yes
+          mix hex.publish --yes --replace
         env:
           HEX_API_KEY: ${{ secrets.HEX_API_KEY }}
       - name: Update Storybook dependency


### PR DESCRIPTION
the latest commit didn't get released due to a race condition:
- commit 1 published to hex, didn't commit release changes, yet
- commit 2 started
- commit 2 tried to publish to hex – with the same version as commit 1 as the changes were not committed, yet. **Fails**
- commit 1 commits changes

I think it's ok to replace the hex version as the version should get replaced almost immediately after release. Otherwise, we'd need to shuffle around the steps. That's also a possible alternative since the storybook depends on the local version of noora, but I have the feeling we might introduce a race condition of a different sort 😅 