### PR TITLE
feat: make text input shortcut key optional

### DIFF
--- a/storybook/storybook/text_input.story.exs
+++ b/storybook/storybook/text_input.story.exs
@@ -49,6 +49,15 @@ defmodule TuistWeb.Storybook.TextInput do
             }
           },
           %Variation{
+            id: :search_without_shortcut,
+            attributes: %{
+              type: "search",
+              name: "search_without_shortcut",
+              placeholder: "Search without shortcut...",
+              show_shortcut_key: false
+            }
+          },
+          %Variation{
             id: :password,
             attributes: %{
               name: "card_number",

--- a/web/lib/noora/text_input.ex
+++ b/web/lib/noora/text_input.ex
@@ -59,6 +59,11 @@ defmodule Noora.TextInput do
     doc: "Whether to show the suffix."
   )
 
+  attr(:show_shortcut_key, :boolean,
+    default: true,
+    doc: "Whether to show the shortcut key button when type is `search`."
+  )
+
   attr(:suffix_hint, :string,
     default: nil,
     doc: "Hint text to show as tooltip at the end of the input. Takes precedence over the suffix set by `type`."
@@ -155,12 +160,17 @@ defmodule Noora.TextInput do
         <div
           :if={
             @show_suffix and @type in ~w(card_number search password) and is_nil(@suffix_hint) and
-              !has_slot_content?(@suffix, assigns)
+              !has_slot_content?(@suffix, assigns) and
+              (@type != "search" or @show_shortcut_key)
           }
           data-part="suffix"
           data-type={@type}
         >
-          <.type_suffix type={type(@type, @input_type)} input_id={@id} />
+          <.type_suffix
+            type={type(@type, @input_type)}
+            input_id={@id}
+            show_shortcut_key={@show_shortcut_key}
+          />
         </div>
         {# Custom suffix #}
         <span :if={@show_suffix and has_slot_content?(@suffix, assigns)} data-part="suffix">
@@ -228,6 +238,8 @@ defmodule Noora.TextInput do
     </button>
     """
   end
+
+  defp type_suffix(%{show_shortcut_key: false} = assigns), do: ~H""
 
   defp type_suffix(assigns) do
     ~H"""


### PR DESCRIPTION
I need to use the `text_input` with the search type but without showing the shortcut key so I'm adding an attribute to make that configurable.

## Summary (Codex)
- add a `show_shortcut_key` toggle to `Noora.TextInput`
- hide the search shortcut suffix when the toggle is false
- document the configuration in Storybook with a shortcut-free search field