### PR TITLE
feat: add popover component

### DIFF
--- a/storybook/storybook/popover.story.exs
+++ b/storybook/storybook/popover.story.exs
@@ -1,0 +1,35 @@
+defmodule TuistWeb.Storybook.Popover do
+  @moduledoc false
+  use PhoenixStorybook.Story, :component
+
+  alias Noora.Button
+  alias Noora.Icon
+  alias Noora.TextInput
+
+  def function, do: &Noora.Popover.popover/1
+
+  def imports,
+    do: []
+
+  def variations do
+    [
+      %Variation{
+        id: :default,
+        description: "Simple popover with basic content",
+        slots: [
+          """
+          <:trigger :let={attrs}>
+            <button {attrs} style="padding: 8px 16px;">
+              Click me
+            </button>
+          </:trigger>
+          <div style="padding: 16px;">
+            <h3 style="margin: 0 0 8px 0; color: var(--noora-surface-label-primary);">Popover Title</h3>
+            <p style="margin: 0; color: var(--noora-surface-label-secondary);">This is the content inside the popover.</p>
+          </div>
+          """
+        ]
+      }
+    ]
+  end
+end

--- a/web/css/index.css
+++ b/web/css/index.css
@@ -16,6 +16,7 @@
 @import "./line_divider.css";
 @import "./modal.css";
 @import "./pagination_group.css";
+@import "./popover.css";
 @import "./progress_bar.css";
 @import "./select.css";
 @import "./shortcut_key.css";

--- a/web/css/popover.css
+++ b/web/css/popover.css
@@ -1,0 +1,16 @@
+.noora-popover {
+  & [data-part="positioner"] {
+    display: none;
+    z-index: var(--noora-z-index-10);
+  }
+
+  & > [data-state="open"] + [data-part="positioner"] {
+    display: block;
+  }
+
+  & [data-part="content"] {
+    box-shadow: var(--noora-border-light-default);
+    border-radius: var(--noora-radius-large);
+    background: var(--noora-surface-background-primary);
+  }
+}

--- a/web/js/Popover.js
+++ b/web/js/Popover.js
@@ -1,5 +1,5 @@
 import * as popover from "@zag-js/popover";
-import { normalizeProps, renderPart } from "./util.js";
+import { getBooleanOption, normalizeProps, renderPart } from "./util.js";
 import { Component } from "./component.js";
 import { VanillaMachine } from "./machine.js";
 
@@ -29,6 +29,21 @@ export default {
   mounted() {
     this.context = {
       id: this.el.id,
+      modal: getBooleanOption(this.el, "modal"),
+      autoFocus: getBooleanOption(this.el, "autoFocus"),
+      closeOnInteractOutside: getBooleanOption(
+        this.el,
+        "closeOnInteractOutside",
+      ),
+      closeOnEscape: getBooleanOption(this.el, "closeOnEscape"),
+      positioning: {
+        placement: this.el.dataset.positioningPlacement,
+      },
+      onOpenChange: (details) => {
+        if (this.el.dataset.onOpenChange) {
+          this.pushEvent(this.el.dataset.onOpenChange, details);
+        }
+      },
     };
     this.popover = new Popover(this.el, this.context);
     this.popover.init();

--- a/web/lib/noora.ex
+++ b/web/lib/noora.ex
@@ -27,6 +27,7 @@ defmodule Noora do
       import Noora.LineDivider
       import Noora.Modal
       import Noora.PaginationGroup
+      import Noora.Popover
       import Noora.ProgressBar
       import Noora.Select
       import Noora.ShortcutKey

--- a/web/lib/noora/popover.ex
+++ b/web/lib/noora/popover.ex
@@ -1,0 +1,73 @@
+defmodule Noora.Popover do
+  @moduledoc """
+  Renders a popover component with a trigger and customizable content.
+
+  ## Example
+
+  ```elixir
+  <.popover id="settings-popover">
+    <:trigger :let={attrs}>
+      <button {attrs}>Settings</button>
+    </:trigger>
+    <div>
+      <h3>Popover Content</h3>
+      <p>This is the content inside the popover.</p>
+    </div>
+  </.popover>
+
+  <.popover id="form-popover" placement="bottom-end">
+    <:trigger :let={attrs}>
+      <span {attrs}><.icon name="filter" /></span>
+    </:trigger>
+    <form phx-submit="save">
+      <.text_input name="name" label="Name" />
+      <.button type="submit" label="Save" />
+    </form>
+  </.popover>
+  ```
+  """
+  use Phoenix.Component
+
+  attr(:id, :string, required: true, doc: "Unique identifier for the popover")
+  attr(:modal, :boolean, default: false, doc: "Enables focus trapping and interaction blocking outside the popover")
+  attr(:auto_focus, :boolean, default: true, doc: "Automatically focuses first focusable element when opened")
+  attr(:close_on_interact_outside, :boolean, default: true, doc: "Controls whether clicking outside closes the popover")
+  attr(:close_on_escape, :boolean, default: true, doc: "Determines if pressing Escape closes the popover")
+
+  attr(:placement, :string,
+    default: "bottom",
+    values: ~w(top top-start top-end bottom bottom-start bottom-end),
+    doc: "Positioning placement: top, top-start, top-end, bottom, bottom-start, bottom-end"
+  )
+
+  attr(:on_open_change, :string, default: nil, doc: "Phoenix event to push when popover state changes")
+
+  attr(:rest, :global, doc: "Additional HTML attributes")
+
+  slot(:trigger, required: true, doc: "Trigger element for the popover")
+  slot(:inner_block, required: true, doc: "Content to be rendered inside the popover")
+
+  def popover(assigns) do
+    ~H"""
+    <div
+      id={@id}
+      class="noora-popover"
+      phx-hook="NooraPopover"
+      data-modal={@modal}
+      data-auto-focus={@auto_focus}
+      data-close-on-interact-outside={@close_on_interact_outside}
+      data-close-on-escape={@close_on_escape}
+      data-positioning-placement={@placement}
+      data-on-open-change={@on_open_change}
+      {@rest}
+    >
+      {render_slot(@trigger, %{"data-part" => "trigger"})}
+      <div data-part="positioner">
+        <div data-part="content">
+          {render_slot(@inner_block)}
+        </div>
+      </div>
+    </div>
+    """
+  end
+end


### PR DESCRIPTION
Adding a popover component needed for cache analytics in the tuist dashboard:
<img width="1059" height="398" alt="image" src="https://github.com/user-attachments/assets/2a12d608-f976-4923-b2eb-8cf9db0e69e6" />
