### PR TITLE
fix: label not shown when existing slots

### DIFF
--- a/web/lib/noora/dropdown.ex
+++ b/web/lib/noora/dropdown.ex
@@ -246,10 +246,10 @@ defmodule Noora.Dropdown do
           {render_slot(@left_icon)}
         </div>
         <div data-part="body">
-          <span :if={Map.get(assigns, :inner_block, []) != []} data-part="label">
+          <span :if={!@label} data-part="label">
             {render_slot(@inner_block)}
           </span>
-          <span :if={Map.get(assigns, :inner_block, []) == []} data-part="label">{@label}</span>
+          <span :if={@label} data-part="label">{@label}</span>
           <span :if={@secondary_text} data-part="secondary-text">
             ({@secondary_text})
           </span>


### PR DESCRIPTION
When a label is defined but the dropdown item has a slot (without content), we try to show the empty content. Instead, we should prefer showing the label and only try to show the inner block if it's not defined.