### PR TITLE
fix: Fix emoji and CJKV width calculations causing incorrect table rendering

### DIFF
--- a/cli/Sources/Noora/Components/MultipleChoicePrompt.swift
+++ b/cli/Sources/Noora/Components/MultipleChoicePrompt.swift
@@ -215,7 +215,7 @@ struct MultipleChoicePrompt {
         guard let terminalWidth = terminal.size()?.columns else { return 1 }
         let lines = text.raw.split(separator: "\n")
         return lines.reduce(0) { sum, line in
-            let lineCount = (line.count + terminalWidth - 1) / terminalWidth
+            let lineCount = (line.displayWidth + terminalWidth - 1) / terminalWidth
             return sum + lineCount
         }
     }

--- a/cli/Sources/Noora/Components/SingleChoicePrompt.swift
+++ b/cli/Sources/Noora/Components/SingleChoicePrompt.swift
@@ -150,7 +150,7 @@ struct SingleChoicePrompt {
         guard let terminalWidth = terminal.size()?.columns else { return 1 }
         let lines = text.raw.split(separator: "\n")
         return lines.reduce(0) { sum, line in
-            let lineCount = (line.count + terminalWidth - 1) / terminalWidth
+            let lineCount = (line.displayWidth + terminalWidth - 1) / terminalWidth
             return sum + lineCount
         }
     }

--- a/cli/Sources/Noora/Components/Table/SelectableTable.swift
+++ b/cli/Sources/Noora/Components/Table/SelectableTable.swift
@@ -225,10 +225,12 @@ struct SelectableTable {
 
             // Cell content
             let plainText = cell.plain()
-            let truncatedText = plainText.count > width ? String(plainText.prefix(width - 1)) + "…" : plainText
+            let truncatedText = plainText.displayWidth > width
+                ? plainText.truncated(toDisplayWidth: max(0, width - 1)) + "…"
+                : plainText
 
             // Apply alignment and create full-width cell
-            let contentPadding = width - truncatedText.count
+            let contentPadding = width - truncatedText.displayWidth
             let cellContent: String
 
             switch alignment {

--- a/cli/Sources/Noora/Components/Table/TableRenderer.swift
+++ b/cli/Sources/Noora/Components/Table/TableRenderer.swift
@@ -32,8 +32,8 @@ struct TableRenderer {
 
             case .auto:
                 // Calculate based on content
-                let headerWidth = column.title.plain().count
-                let maxContentWidth = data.rows.map { $0[index].plain().count }.max() ?? 0
+                let headerWidth = column.title.displayWidth
+                let maxContentWidth = data.rows.map { $0[index].displayWidth }.max() ?? 0
                 columnWidths[index] = max(headerWidth, maxContentWidth)
                 usedWidth += columnWidths[index]
             }
@@ -119,16 +119,17 @@ struct TableRenderer {
         terminal: Terminaling
     ) -> String {
         let text = content.plain()
+        let textWidth = text.displayWidth
         let formatted = content.formatted(theme: theme, terminal: terminal)
 
         // Handle text that's too long
-        if text.count > width {
-            let truncated = String(text.prefix(width - 1)) + "…"
+        if textWidth > width {
+            let truncated = text.truncated(toDisplayWidth: max(0, width - 1)) + "…"
             return TerminalText(stringLiteral: truncated).formatted(theme: theme, terminal: terminal)
         }
 
         // Apply alignment
-        let padding = width - text.count
+        let padding = width - textWidth
         switch alignment {
         case .left:
             return formatted + String(repeating: " ", count: padding)

--- a/cli/Sources/Noora/Utilities/TerminalText+DisplayWidth.swift
+++ b/cli/Sources/Noora/Utilities/TerminalText+DisplayWidth.swift
@@ -1,0 +1,52 @@
+extension TerminalText {
+    public var displayWidth: Int {
+        plain().displayWidth
+    }
+}
+
+extension Character {
+    /// The approximate display width for a character in a terminal.
+    ///
+    /// There is no standard for this, but it seems like most terminals treat
+    /// emojis and ideographs as double width.
+    public var displayWidth: Int {
+        if unicodeScalars.contains(where: \.properties.isEmojiPresentation) {
+            return 2
+        } else if unicodeScalars.contains(where: \.properties.isIdeographic) {
+            return 2
+        } else {
+            return 1
+        }
+    }
+}
+
+extension Substring {
+    public var displayWidth: Int {
+        reduce(into: 0) { $0 += $1.displayWidth }
+    }
+}
+
+extension String {
+    public var displayWidth: Int {
+        reduce(into: 0) { $0 += $1.displayWidth }
+    }
+
+    /// Truncates to a target display width without splitting scalars.
+    func truncated(toDisplayWidth targetWidth: Int) -> String {
+        guard targetWidth > 0 else { return "" }
+
+        var collected = ""
+        var currentWidth = 0
+
+        for character in self {
+            let width = character.displayWidth
+            if currentWidth + width > targetWidth {
+                break
+            }
+            currentWidth += width
+            collected.append(character)
+        }
+
+        return collected
+    }
+}

--- a/cli/Tests/NooraTests/Components/TableTests.swift
+++ b/cli/Tests/NooraTests/Components/TableTests.swift
@@ -89,6 +89,50 @@ struct TableTests {
         }
     }
 
+    @Test func table_respects_emoji_width() throws {
+        // Given
+        let columns = [
+            TableColumn(title: TerminalText(stringLiteral: "E"), width: .auto, alignment: .left),
+            TableColumn(title: TerminalText(stringLiteral: "Name"), width: .auto, alignment: .left),
+        ]
+        let rows = [
+            [TerminalText(stringLiteral: "😀"), TerminalText(stringLiteral: "Alpha")],
+            [TerminalText(stringLiteral: "😃"), TerminalText(stringLiteral: "Beta")],
+        ]
+        let data = TableData(columns: columns, rows: rows)
+        let style = TableStyle(theme: .test())
+
+        let standardOutput = MockStandardPipeline()
+        let standardError = MockStandardPipeline()
+        let standardPipelines = StandardPipelines(output: standardOutput, error: standardError)
+
+        let subject = Table(
+            data: data,
+            style: style,
+            renderer: renderer,
+            standardPipelines: standardPipelines,
+            terminal: terminal,
+            theme: theme,
+            logger: logger,
+            tableRenderer: TableRenderer()
+        )
+
+        // When
+        subject.run()
+
+        // Then
+        let expectedOutput = """
+        ╭────┬───────╮
+        │ E  │ Name  │
+        ├────┼───────┤
+        │ 😀 │ Alpha │
+        │ 😃 │ Beta  │
+        ╰────┴───────╯
+        """
+
+        #expect(renderer.renders.joined(separator: "\r") == expectedOutput)
+    }
+
     @Test func table_output_structure() throws {
         // Given
         let columns = [

--- a/cli/Tests/NooraTests/Utilities/DisplayWidthTests.swift
+++ b/cli/Tests/NooraTests/Utilities/DisplayWidthTests.swift
@@ -1,0 +1,30 @@
+import Testing
+
+@testable import Noora
+
+struct DisplayWidthTests {
+    @Test func measures_common_widths() {
+        #expect("abc".displayWidth == 3)
+        #expect("✓".displayWidth == 1)
+        #expect("😀".displayWidth == 2)
+        #expect("🇺🇸".displayWidth == 2)
+        #expect("界".displayWidth == 2)
+        #expect("👨‍👩‍👦".displayWidth == 2)
+        #expect("👨‍👩‍👦界🇺🇸".displayWidth == 6)
+        #expect("👨‍👩‍👦界🇺🇸abc".displayWidth == 9)
+        #expect(TerminalText(stringLiteral: "😀").displayWidth == 2)
+        #expect(TerminalText(components: [.muted("😀")]).displayWidth == 2)
+        #expect(TerminalText(components: [.info("abc")]).displayWidth == 3)
+    }
+
+    @Test func truncates_by_display_width() {
+        let emojiTrimmed = "😀abc".truncated(toDisplayWidth: 3)
+        #expect(emojiTrimmed == "😀a")
+
+        let zwjTrimmed = "👨‍👩‍👦abc".truncated(toDisplayWidth: 2)
+        #expect(zwjTrimmed == "👨‍👩‍👦")
+
+        let cjkTrimmed = "界界abc".truncated(toDisplayWidth: 4)
+        #expect(cjkTrimmed == "界界")
+    }
+}


### PR DESCRIPTION
Adds `TerminalText/Character/String .displayWidth` to return `2` for `isEmojiPresentation/isIdeographic`, and `1` otherwise. There is no standard for this which is quite annoying, but every terminal I've tested renders both of these as 2 character-widths, so I think this is fine to hardcode.

I think there's room for improving this in the future, e.g. use `wcwidth` to handle 0-width characters (uncommon), etc.

| before | after |
|--------|--------|
| <img width="358" height="293" alt="CleanShot 2025-12-02 at 10 29 40@2x" src="https://github.com/user-attachments/assets/d99dc37d-ef73-48ea-bd72-ede65b8792c7" /> | <img width="306" height="261" alt="CleanShot 2025-12-02 at 10 29 43@2x" src="https://github.com/user-attachments/assets/bb325009-1a65-4cb4-9478-86842d17e506" /> | 

