### PR TITLE
feat: Add configurable signal handling behavior

### DIFF
--- a/cli/Sources/Noora/Utilities/KeyStrokeListener.swift
+++ b/cli/Sources/Noora/Utilities/KeyStrokeListener.swift
@@ -63,9 +63,13 @@ public struct KeyStrokeListener: KeyStrokeListening {
             var buffer = ""
 
             loop: while let char = terminal.readCharacter() {
-                // Handle Ctrl+C (character code 3) - exit immediately
+                // Handle Ctrl+C (character code 3) based on terminal's signal behavior
                 if char.unicodeScalars.first?.value == 3 {
-                    exit(0)
+                    terminal.signalBehavior.restoreCursorIfNeeded()
+                    if terminal.signalBehavior == .restoreAndExit {
+                        exit(0)
+                    }
+                    break loop
                 }
 
                 buffer.append(char)
@@ -107,11 +111,15 @@ public struct KeyStrokeListener: KeyStrokeListening {
             }
         #else
             loop: while let char = terminal.readRawCharacter() {
-                // Handle Ctrl+C (character code 3) - exit immediately
+                // Handle Ctrl+C (character code 3) based on terminal's signal behavior
                 // On Windows, Ctrl+C generates character code 3
                 // while "getch" is running it doesn't emit a signal
                 if char == 3 {
-                    exit(0)
+                    terminal.signalBehavior.restoreCursorIfNeeded()
+                    if terminal.signalBehavior == .restoreAndExit {
+                        exit(0)
+                    }
+                    break loop
                 }
 
                 let keyStroke: KeyStroke?

--- a/cli/Tests/NooraTests/Mocks/MockTerminal.swift
+++ b/cli/Tests/NooraTests/Mocks/MockTerminal.swift
@@ -3,6 +3,7 @@
 final class MockTerminal: Terminaling, @unchecked Sendable {
     let _isInteractive: LockIsolated<Bool>
     let _isColored: LockIsolated<Bool>
+    let _signalBehavior: LockIsolated<SignalBehavior>
     private let constantSize: LockIsolated<TerminalSize?>
 
     var isInteractive: Bool {
@@ -13,13 +14,19 @@ final class MockTerminal: Terminaling, @unchecked Sendable {
         _isColored.value
     }
 
+    var signalBehavior: SignalBehavior {
+        _signalBehavior.value
+    }
+
     init(
         isInteractive: Bool = true,
         isColored: Bool = true,
+        signalBehavior: SignalBehavior = .restoreAndExit,
         size: TerminalSize? = nil
     ) {
         _isInteractive = LockIsolated(isInteractive)
         _isColored = LockIsolated(isColored)
+        _signalBehavior = LockIsolated(signalBehavior)
         constantSize = LockIsolated(size)
     }
 

--- a/cli/Tests/NooraTests/Utilities/SignalBehaviorTests.swift
+++ b/cli/Tests/NooraTests/Utilities/SignalBehaviorTests.swift
@@ -1,0 +1,65 @@
+import Testing
+
+@testable import Noora
+
+struct SignalBehaviorTests {
+    @Test func restoreCursorIfNeeded_restoreAndExit_restores_cursor() {
+        // Given
+        let behavior = SignalBehavior.restoreAndExit
+        var output: String?
+
+        // When
+        behavior.restoreCursorIfNeeded { output = $0 }
+
+        // Then
+        #expect(output == "\u{1B}[?25h")
+    }
+
+    @Test func restoreCursorIfNeeded_restoreOnly_restores_cursor() {
+        // Given
+        let behavior = SignalBehavior.restoreOnly
+        var output: String?
+
+        // When
+        behavior.restoreCursorIfNeeded { output = $0 }
+
+        // Then
+        #expect(output == "\u{1B}[?25h")
+    }
+
+    @Test func restoreCursorIfNeeded_none_does_nothing() {
+        // Given
+        let behavior = SignalBehavior.none
+        var output: String?
+
+        // When
+        behavior.restoreCursorIfNeeded { output = $0 }
+
+        // Then
+        #expect(output == nil)
+    }
+
+    @Test func terminal_default_signalBehavior_is_restoreAndExit() {
+        // Given
+        let terminal = MockTerminal()
+
+        // Then
+        #expect(terminal.signalBehavior == .restoreAndExit)
+    }
+
+    @Test func terminal_signalBehavior_can_be_set_to_restoreOnly() {
+        // Given
+        let terminal = MockTerminal(signalBehavior: .restoreOnly)
+
+        // Then
+        #expect(terminal.signalBehavior == .restoreOnly)
+    }
+
+    @Test func terminal_signalBehavior_can_be_set_to_none() {
+        // Given
+        let terminal = MockTerminal(signalBehavior: .none)
+
+        // Then
+        #expect(terminal.signalBehavior == .none)
+    }
+}


### PR DESCRIPTION
This adds a `SignalBehavior` enum that allows users to control how the Terminal handles signals like SIGINT, SIGTERM, etc. The three options are:

- `restoreAndExit`: Restore cursor and exit (default, preserves current behavior)
- `restoreOnly`: Restore cursor but don't exit (for custom shutdown logic)
- `none`: Do nothing, user manages signal handling entirely

This is useful for applications using Swift Service Lifecycle or other frameworks that need to handle graceful shutdown themselves. The `restoreOnly` option is particularly handy since it still fixes the terminal cursor but lets the app decide when and how to exit.

Fixes #786