### PR TITLE
fix: correct emoji width for table alignment

### DIFF
--- a/cli/Sources/Noora/Utilities/TerminalText+DisplayWidth.swift
+++ b/cli/Sources/Noora/Utilities/TerminalText+DisplayWidth.swift
@@ -10,7 +10,10 @@ extension Character {
     /// There is no standard for this, but it seems like most terminals treat
     /// emojis and ideographs as double width.
     public var displayWidth: Int {
-        if unicodeScalars.contains(where: \.properties.isEmojiPresentation) {
+        let hasEmojiPresentation = unicodeScalars.contains(where: \.properties.isEmojiPresentation)
+        let hasEmojiVariationSelector = unicodeScalars.contains { $0.value == 0xFE0F }
+
+        if hasEmojiPresentation || hasEmojiVariationSelector {
             return 2
         } else if unicodeScalars.contains(where: \.properties.isIdeographic) {
             return 2

--- a/cli/Tests/NooraTests/Utilities/DisplayWidthTests.swift
+++ b/cli/Tests/NooraTests/Utilities/DisplayWidthTests.swift
@@ -6,6 +6,7 @@ struct DisplayWidthTests {
     @Test func measures_common_widths() {
         #expect("abc".displayWidth == 3)
         #expect("✓".displayWidth == 1)
+        #expect("✓️".displayWidth == 2)
         #expect("😀".displayWidth == 2)
         #expect("🇺🇸".displayWidth == 2)
         #expect("界".displayWidth == 2)


### PR DESCRIPTION
Emojis were treated as width of 1 but now they should be treated as width of 2. This incorrectly would shift a row in a table off by one space.