### PR TITLE
fix: dropdown item width

### DIFF
--- a/web/css/dropdown.css
+++ b/web/css/dropdown.css
@@ -257,6 +257,7 @@
   }
 
   & [data-part="items"] {
+    align-self: stretch;
     padding: var(--noora-spacing-2);
   }
 }


### PR DESCRIPTION
Before:
<img width="694" height="401" alt="image" src="https://github.com/user-attachments/assets/01ec3f03-7301-4661-a342-6de88ea85e09" />
After:
<img width="694" height="401" alt="image" src="https://github.com/user-attachments/assets/963f6fe3-a785-465b-a486-52324c7abcf3" />
