### PR TITLE
fix: prevent background scroll when modal is open

### DIFF
--- a/web/lib/noora/modal.ex
+++ b/web/lib/noora/modal.ex
@@ -87,6 +87,7 @@ defmodule Noora.Modal do
       phx-hook="NooraModal"
       data-close-on-escape
       data-close-on-interact-outside
+      data-prevent-scroll
       data-on-open-change={@on_open_change}
       phx-update="ignore"
       {@rest}


### PR DESCRIPTION
Before:

https://github.com/user-attachments/assets/db37f98e-ce29-41b6-81ff-19cd5d5d25fa

## Summary
- Add `data-prevent-scroll` attribute to modal component to lock background scrolling when a modal is active

## Problem
When a modal is open, users can still scroll the underlying page content, which is a poor UX experience.

## Solution
Added `data-prevent-scroll` attribute to the modal component's div element. This leverages the existing support in the NooraModal JavaScript hook which uses `@zag-js/dialog`'s `preventScroll` option.

## Test Plan
- [x] Open any modal and verify the background page cannot be scrolled
- [x] Close the modal and verify scrolling is restored

🤖 Generated with [Claude Code](https://claude.com/claude-code)