### PR TITLE
fix: increase modal z-index to appear above breadcrumbs

### DIFF
--- a/web/css/modal.css
+++ b/web/css/modal.css
@@ -5,7 +5,7 @@
     position: fixed;
     top: 0;
     left: 0;
-    z-index: var(--noora-z-index-9);
+    z-index: var(--noora-z-index-11);
     backdrop-filter: blur(2.5px);
     background: var(--noora-surface-overlay);
     width: 100dvw;
@@ -24,7 +24,7 @@
     top: 50%;
     left: 50%;
     transform: translateY(-50%) translateX(-50%);
-    z-index: var(--noora-z-index-10);
+    z-index: var(--noora-z-index-12);
     box-sizing: border-box;
 
     /* Prevent flashing of the component before script load */


### PR DESCRIPTION
Before:
<img width="1261" height="563" alt="image" src="https://github.com/user-attachments/assets/8421c772-5b3f-4e01-beda-435af77fb75e" />

After:
<img width="1261" height="563" alt="image" src="https://github.com/user-attachments/assets/03a59b7e-c22c-4c91-a509-bd3ebe2dffad" />


## Summary
- Fixed modal backdrop appearing behind breadcrumbs in the headerbar
- Increased modal z-index values so the modal properly overlays all UI elements

## Problem
The modal backdrop had `z-index-9` (517) which is lower than breadcrumbs `z-index-10` (518), causing breadcrumbs to appear above the modal backdrop when a modal is open.

## Solution
- Backdrop: `z-index-9` → `z-index-11` (519)
- Positioner: `z-index-10` → `z-index-12` (520)

This ensures the modal appears above all other UI elements like breadcrumbs and dropdowns.

🤖 Generated with [Claude Code](https://claude.com/claude-code)