### PR TITLE
fix: use checked phoenix variable for the toggle state

### DIFF
--- a/web/js/Toggle.js
+++ b/web/js/Toggle.js
@@ -24,10 +24,6 @@ export default {
     this.toggle.init();
   },
 
-  updated() {
-    this.toggle.render();
-  },
-
   beforeDestroy() {
     this.toggle.destroy();
   },
@@ -35,11 +31,11 @@ export default {
   context() {
     return {
       id: this.el.id,
-      defaultChecked: getBooleanOption(this.el, "defaultChecked"),
+      checked: getBooleanOption(this.el, "checked"),
       disabled: getBooleanOption(this.el, "disabled"),
-      onCheckChange: (details) => {
-        if (this.el.dataset.onChange) {
-          this.pushEvent(this.el.dataset.onCheckChange, details);
+      onCheckedChange: (details) => {
+        if (this.el.dataset.onCheckedChange) {
+          this.pushEvent(this.el.dataset.onCheckedChange, details);
         }
       },
     };

--- a/web/lib/noora/toggle.ex
+++ b/web/lib/noora/toggle.ex
@@ -42,7 +42,7 @@ defmodule Noora.Toggle do
       name={@name}
       class="noora-toggle"
       phx-hook="NooraToggle"
-      data-default-checked={@checked}
+      data-checked={@checked}
       data-disabled={@disabled}
       {@rest}
     >


### PR DESCRIPTION
We don't re-render on `update` to let phoenix layer handle fully the `checked` state.