### PR TITLE
fix(avatar): handle names with consecutive delimiters

### DIFF
--- a/web/lib/noora/avatar.ex
+++ b/web/lib/noora/avatar.ex
@@ -79,6 +79,7 @@ defmodule Noora.Avatar do
       <span :if={@fallback == "initials"} data-part="initials">
         {@name
         |> String.split(~r/[\s,_\-]/)
+        |> Enum.reject(&(&1 == ""))
         |> Enum.take(@number_of_initials)
         |> Enum.map(&String.first/1)
         |> Enum.map(&String.upcase/1)


### PR DESCRIPTION
## Summary
- Fix `FunctionClauseError` in avatar component when name contains consecutive delimiters

## Problem
When a name contains consecutive delimiters (e.g., `john--doe` or `jane__smith`), `String.split(~r/[\s,_\-]/)` produces empty strings in the result list:

```elixir
String.split("john--doe", ~r/[\s,_\-]/)
# => ["john", "", "doe"]
```

Then `String.first("")` returns `nil`, which causes `String.upcase(nil)` to fail with:

```
** (FunctionClauseError) no function clause matching in String.upcase/2
```

## Solution
Filter out empty strings after splitting before processing initials:

```elixir
@name
|> String.split(~r/[\s,_\-]/)
|> Enum.reject(&(&1 == ""))  # <- added
|> Enum.take(@number_of_initials)
|> Enum.map(&String.first/1)
|> Enum.map(&String.upcase/1)
|> Enum.join()
```

## Test plan
- [x] Tested with names containing consecutive delimiters (e.g., `test--user`)
- [x] Verified existing avatar functionality still works

🤖 Generated with [Claude Code](https://claude.ai/code)