### PR TITLE
fix(cli): log TerminalText as plain text

### DIFF
--- a/cli/Sources/Noora/Utilities/TerminalText.swift
+++ b/cli/Sources/Noora/Utilities/TerminalText.swift
@@ -88,6 +88,12 @@ public struct TerminalText: Equatable, Hashable, Sendable {
     }
 }
 
+extension TerminalText: CustomStringConvertible {
+    public var description: String {
+        plain()
+    }
+}
+
 extension TerminalText: ExpressibleByStringInterpolation {
     public init(stringLiteral value: String) {
         components = [.raw(value)]

--- a/cli/Tests/NooraTests/Utilities/TerminalTextTests.swift
+++ b/cli/Tests/NooraTests/Utilities/TerminalTextTests.swift
@@ -68,4 +68,10 @@ struct TerminalTextTests {
         \u{1B}[38;5;38mA string with the theme's info color\u{1B}[0m
         """)
     }
+
+    @Test func descriptionUsesPlainText() {
+        let subject: TerminalText = "Visit \(.link(title: "Tuist", href: "https://tuist.dev")) and run \(.command("tuist"))"
+
+        #expect(String(describing: subject) == "Visit (Tuist) and run 'tuist'")
+    }
 }


### PR DESCRIPTION
## Summary
- Use `TerminalText.description` to return plain text so session logs stay readable
- Add a test covering description output

## Context
Verbose session logs were dumping `TerminalText` components instead of the rendered text.

## Testing
- Not run (not requested)
