### PR TITLE
fix(ci): repeat --include-path for each path in Release CLI workflow

### DIFF
--- a/.github/workflows/release-cli.yml
+++ b/.github/workflows/release-cli.yml
@@ -58,14 +58,14 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          NEXT_VERSION=$(git cliff --config cli/cliff.toml --include-path "cli/**" "Package.swift" "Package.resolved" --bumped-version)
+          NEXT_VERSION=$(git cliff --config cli/cliff.toml --include-path "cli/**" --include-path "Package.swift" --include-path "Package.resolved" --bumped-version)
           echo "NEXT_VERSION=$NEXT_VERSION" >> "$GITHUB_OUTPUT"
           echo "Next CLI version will be: $NEXT_VERSION"
       - name: Update CHANGELOG.md
         if: steps.check-changes.outputs.has-changes == 'true'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: git cliff --config cli/cliff.toml --include-path "cli/**" "Package.swift" "Package.resolved" --bump -o cli/CHANGELOG.md
+        run: git cliff --config cli/cliff.toml --include-path "cli/**" --include-path "Package.swift" --include-path "Package.resolved" --bump -o cli/CHANGELOG.md
       - name: Get release notes
         id: release-notes
         if: steps.check-changes.outputs.has-changes == 'true'
@@ -73,7 +73,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           echo "RELEASE_NOTES<<EOF" >> "$GITHUB_OUTPUT"
-          git cliff --config cli/cliff.toml --include-path "cli/**" "Package.swift" "Package.resolved" --latest >> "$GITHUB_OUTPUT"
+          git cliff --config cli/cliff.toml --include-path "cli/**" --include-path "Package.swift" --include-path "Package.resolved" --latest >> "$GITHUB_OUTPUT"
           echo "EOF" >> "$GITHUB_OUTPUT"
       - name: Commit changes
         id: auto-commit-action


### PR DESCRIPTION
## What

`git-cliff` 2.x treats extra positional arguments after `--include-path` as the `[RANGE]` argument rather than as additional path patterns. The current invocation

\`\`\`
git cliff --config cli/cliff.toml --include-path \"cli/**\" \"Package.swift\" \"Package.resolved\" --bumped-version
\`\`\`

therefore fails with

\`\`\`
error: unexpected argument 'Package.resolved' found
\`\`\`

on the very first step of the workflow, which is why the last merged CLI change didn't cut a release. Repeat the flag for each pattern so each path is picked up as its own \`--include-path\` value. Functionally equivalent to the intent of the original invocation.

## Follow-up

Once this merges the Release CLI workflow runs cleanly and the CLI release that got skipped picks up on the next push to \`main\` (or via workflow_dispatch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)