### PR TITLE
fix: widen swift-log version range to accept 1.13.x consumers

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -22,7 +22,7 @@ let package = Package(
         .package(
             url: "https://github.com/apple/swift-argument-parser", .upToNextMajor(from: "1.8.2")
         ),
-        .package(url: "https://github.com/apple/swift-log", .upToNextMajor(from: "1.15.1")),
+        .package(url: "https://github.com/apple/swift-log", "1.5.3" ..< "2.0.0"),
         .package(url: "https://github.com/tuist/path", .upToNextMinor(from: "0.3.8")),
     ],
     targets: [


### PR DESCRIPTION
## Summary

Renovate has been tightening `apple/swift-log` to `.upToNextMajor(from: "1.15.x")` each time a new patch lands. The library itself only uses the log-level helpers with a positional `Logger.Message` (`logger?.debug("...")`), which compile identically against every 1.x release, so the tight floor doesn't buy anything at runtime.

The downside is real for downstream consumers. Noora is picked up in the Tuist CLI, which pins `apple.swift-log` below `1.14` because swift-log 1.15 added a `Logger.current` static that collides with the CLI's own `@TaskLocal` extension of the same name. Migrating those call sites is a separate, larger piece of work; while it's outstanding, Noora 0.57.1 wasn't resolvable inside Tuist and the resolver silently fell back to 0.56.0, which meant the stdout-fflush fix on non-Apple platforms from #1191 wasn't shipping.

Widen the range to `1.5.3 ..< 2.0.0` so consumers can converge on the highest 1.x that fits the rest of their graph.

## Verification

- Local resolve inside the Tuist CLI worktree now picks Noora 0.57.2 alongside swift-log 1.13.2, unblocking the Rosalind bundle-inspect fix that needs to ship for a customer.
- No source changes required inside Noora since `logger?.debug/notice/etc.` are unambiguous across the entire 1.x line.

## Test plan
- [ ] CI passes on the Noora side
- [ ] Confirm the released 0.57.2 resolves cleanly inside `tuist/tuist`

🤖 Generated with [Claude Code](https://claude.com/claude-code)