### PR TITLE
fix(ci): detect root Package.swift/Package.resolved changes for Release CLI

### DIFF
--- a/.github/workflows/release-cli.yml
+++ b/.github/workflows/release-cli.yml
@@ -44,7 +44,7 @@ jobs:
             echo "No previous CLI releases found, will release"
             echo "has-changes=true" >> $GITHUB_OUTPUT
           else
-            if git diff --name-only ${LAST_CLI_TAG}..HEAD | grep -E '^cli/' > /dev/null; then
+            if git diff --name-only ${LAST_CLI_TAG}..HEAD | grep -E '^(cli/|Package\.swift$|Package\.resolved$)' > /dev/null; then
               echo "CLI changes found since $LAST_CLI_TAG"
               echo "has-changes=true" >> $GITHUB_OUTPUT
             else


### PR DESCRIPTION
## Summary

The Release CLI workflow triggers on pushes that touch `cli/**`, `Package.swift`, or `Package.resolved`, but the internal "Check for CLI changes since last release" gate only greps for the `^cli/` prefix. A push that only modifies the root `Package.swift` (for example, PR #1193 that widened the `swift-log` range) starts the workflow, then the gate reports "No CLI changes" and skips version bump plus tag creation. The trigger paths and the gate disagree, so a fix-typed commit that only touches the SPM manifest never ships as a release.

Widen the diff grep to match the same set of paths the workflow triggers on, so any push that starts the workflow can trip the gate.

## Verification

- Concrete case: PR #1193 merged into main, the Release CLI workflow ran, the gate emitted "No CLI changes since 0.57.1", and no 0.57.2 tag was cut even though the change was labelled `fix:`.
- After this workflow fix, the next Package.swift-only push will bump correctly.

## Test plan
- [ ] Confirm the follow-up release after merging cuts 0.57.2 for the widened swift-log range.

🤖 Generated with [Claude Code](https://claude.com/claude-code)