### PR TITLE
fix(renovate): wait out pnpm's minimumReleaseAge before opening npm PRs

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -18,6 +18,11 @@
       "semanticCommitScope": "spm"
     },
     {
+      "description": "pnpm 12 rejects lockfile entries published within its default 24h minimumReleaseAge supply-chain policy. Wait longer than that window so npm updates land with a lockfile CI will accept.",
+      "matchManagers": ["npm"],
+      "minimumReleaseAge": "3 days"
+    },
+    {
       "matchPackageNames": ["phoenix_storybook"],
       "enabled": false
     }


### PR DESCRIPTION
## Problem

pnpm 12 enforces a supply-chain policy that rejects lockfile entries published within the last 24 hours. Renovate has no matching delay, so it opens npm update PRs within hours of a release and CI fails on `pnpm install` before the build even starts:

```
ERR_PNPM_MINIMUM_RELEASE_AGE_VIOLATION
  miniflare@5.20260910.0-alpha published 2026-09-10T15:16:23Z, within cutoff
  wrangler@4.131.0     published 2026-09-10T15:17:45Z, within cutoff
```

This arrived silently with #1185. That PR bumped pnpm 10.34.5 → 12.3.4 and renamed `onlyBuiltDependencies` → `allowBuilds` — it never configured a release-age policy. The 24h window is a **pnpm 12 default**; there is no `minimumReleaseAge` anywhere in the repo and no `.npmrc`.

The timing is the giveaway:

| | |
|---|---|
| 21:46:04 UTC | #1185 merges → pnpm 12's 24h policy goes live |
| 21:47:34 UTC | #1196's Build fails on it, 90 seconds later |

#1196 was simply the first npm dependency PR to run under the new default.

## Why this needs fixing beyond that one PR

Left as-is, every future npm PR Renovate opens fails the same way. Worse, `.github/workflows/deploy.yml` also runs `pnpm install` on `main`, so merging inside the window would break the docs deploy too.

## Change

Hold npm updates for 3 days so the lockfile Renovate commits is one CI will accept, with margin over pnpm's 24h window. Scoped to the `npm` manager only — the policy doesn't apply to the Swift or GitHub Actions managers.

Verified with Renovate's official `renovate-config-validator`: *"Config validated successfully."*

## Note on a residual gap

`lockFileMaintenance` is enabled with automerge. It regenerates the whole lockfile, and Renovate's `minimumReleaseAge` doesn't constrain freshly-resolved *transitive* packages — so that job can still occasionally trip the policy. Narrowing its schedule would help, but that felt like a separate judgment call rather than something to fold in here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)